### PR TITLE
Fix total equity heading text

### DIFF
--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -38,7 +38,7 @@ export default function SummaryMetrics({
   onRefresh,
   displayTotalEquity,
 }) {
-  const title = currencyOption?.title || 'Total equity';
+  const title = 'Total equity (Combined in CAD)';
   const totalEquity = balances?.totalEquity ?? null;
   const marketValue = balances?.marketValue ?? null;
   const cash = balances?.cash ?? null;


### PR DESCRIPTION
## Summary
- keep the total equity card heading static so the currency buttons do not alter it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9ce2850e4832db6fae893a9cdb7b1