### PR TITLE
Hide unused accounts from account selector

### DIFF
--- a/client/src/components/AccountSelector.jsx
+++ b/client/src/components/AccountSelector.jsx
@@ -117,6 +117,18 @@ function buildSecondaryLabel(account, totalAccounts) {
   return parts.join(' - ') || null;
 }
 
+const HIDDEN_ACCOUNT_PATTERN = /(?:not\s*used|unused)/i;
+
+function shouldHideAccountOption(option) {
+  if (!option) {
+    return false;
+  }
+  const fieldsToCheck = [option.primary, option.meta, option.secondary];
+  return fieldsToCheck.some(
+    (field) => typeof field === 'string' && HIDDEN_ACCOUNT_PATTERN.test(field)
+  );
+}
+
 function buildAccountOption(account, context) {
   if (!account) {
     return null;
@@ -176,7 +188,7 @@ export default function AccountSelector({ accounts, selected, onChange, disabled
   const optionsState = useMemo(() => {
     const accountOptions = accounts
       .map((account) => buildAccountOption(account, { multipleOwners, totalAccounts }))
-      .filter(Boolean);
+      .filter((option) => option && !shouldHideAccountOption(option));
     const allOption = buildAllOption(totalAccounts, accountOptions, multipleOwners);
     const optionsList = [];
     if (allOption) {

--- a/client/src/components/AccountSelector.jsx
+++ b/client/src/components/AccountSelector.jsx
@@ -119,14 +119,30 @@ function buildSecondaryLabel(account, totalAccounts) {
 
 const HIDDEN_ACCOUNT_PATTERN = /(?:not\s*used|unused)/i;
 
+function containsHiddenKeyword(value) {
+  if (value == null) {
+    return false;
+  }
+  const stringValue = typeof value === 'string' ? value : String(value);
+  return HIDDEN_ACCOUNT_PATTERN.test(stringValue);
+}
+
 function shouldHideAccountOption(option) {
   if (!option) {
     return false;
   }
-  const fieldsToCheck = [option.primary, option.meta, option.secondary];
-  return fieldsToCheck.some(
-    (field) => typeof field === 'string' && HIDDEN_ACCOUNT_PATTERN.test(field)
-  );
+  const fieldsToCheck = [
+    option.primary,
+    option.meta,
+    option.secondary,
+    option.account?.displayName,
+    option.account?.ownerLabel,
+    option.account?.clientAccountType,
+    option.account?.type,
+    option.account?.number,
+    option.account?.name,
+  ];
+  return fieldsToCheck.some(containsHiddenKeyword);
 }
 
 function buildAccountOption(account, context) {


### PR DESCRIPTION
## Summary
- hide account selector options whose labels include "Not Used" or "Unused"
- ensure hidden accounts are still considered when calculating aggregate totals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9d0c49348832daf521c18d65cccb1