### PR TITLE
Increase account dropdown height

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -176,7 +176,7 @@ textarea {
 }
 
 .account-selector__list {
-  max-height: 320px;
+  max-height: 512px;
   overflow-y: auto;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- enlarge the account selector dropdown list so more accounts are visible at once

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9d0e3ed90832d9cabb62c6302c122