### PR TITLE
Display USD to CAD exchange rate in summary view

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -304,6 +304,24 @@ textarea {
   letter-spacing: -0.01em;
 }
 
+.equity-card__subtext {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.equity-card__subtext-label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.equity-card__subtext-value {
+  font-variant-numeric: tabular-nums;
+}
+
 .time-pill {
   display: inline-flex;
   align-items: center;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -598,6 +598,14 @@ export default function App() {
   const baseCurrency = 'CAD';
   const currencyRates = useMemo(() => buildCurrencyRateMap(balances, baseCurrency), [balances]);
 
+  const usdToCadRate = useMemo(() => {
+    const rate = currencyRates.get('USD');
+    if (isFiniteNumber(rate) && rate > 0) {
+      return rate;
+    }
+    return null;
+  }, [currencyRates]);
+
   const positions = useMemo(() => {
     if (selectedAccount === 'all') {
       return aggregatePositionsBySymbol(rawPositions, { currencyRates, baseCurrency });
@@ -765,6 +773,7 @@ export default function App() {
             asOf={asOf}
             onRefresh={handleRefresh}
             displayTotalEquity={displayTotalEquity}
+            usdToCadRate={usdToCadRate}
           />
         )}
 

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -1,6 +1,12 @@
 import PropTypes from 'prop-types';
 import TimePill from './TimePill';
-import { classifyPnL, formatMoney, formatSignedMoney, formatSignedPercent } from '../utils/formatters';
+import {
+  classifyPnL,
+  formatMoney,
+  formatNumber,
+  formatSignedMoney,
+  formatSignedPercent,
+} from '../utils/formatters';
 
 function MetricRow({ label, value, extra, tone, className }) {
   const rowClass = className ? `equity-card__metric-row ${className}` : 'equity-card__metric-row';
@@ -37,6 +43,7 @@ export default function SummaryMetrics({
   asOf,
   onRefresh,
   displayTotalEquity,
+  usdToCadRate,
 }) {
   const title = currencyOption?.title || 'Total equity';
   const totalEquity = balances?.totalEquity ?? null;
@@ -65,6 +72,14 @@ export default function SummaryMetrics({
         <div className="equity-card__heading">
           <h2 className="equity-card__title">{title}</h2>
           <p className="equity-card__value">{formatMoney(displayTotalEquity ?? totalEquity)}</p>
+          {usdToCadRate !== null && (
+            <p className="equity-card__subtext">
+              <span className="equity-card__subtext-label">USD → CAD</span>
+              <span className="equity-card__subtext-value">
+                {formatNumber(usdToCadRate, { minimumFractionDigits: 3, maximumFractionDigits: 3 })}
+              </span>
+            </p>
+          )}
         </div>
         <TimePill asOf={asOf} onRefresh={onRefresh} />
       </header>
@@ -143,6 +158,7 @@ SummaryMetrics.propTypes = {
   asOf: PropTypes.string,
   onRefresh: PropTypes.func,
   displayTotalEquity: PropTypes.number,
+  usdToCadRate: PropTypes.number,
 };
 
 SummaryMetrics.defaultProps = {
@@ -151,4 +167,5 @@ SummaryMetrics.defaultProps = {
   asOf: null,
   onRefresh: null,
   displayTotalEquity: null,
+  usdToCadRate: null,
 };


### PR DESCRIPTION
## Summary
- show the derived USD→CAD exchange rate in the summary metrics header and format it to three decimals
- style the exchange rate subtext so it aligns with the existing equity card layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da71120374832da40732f71d524044