### PR TITLE
Fix total equity label text

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -74,7 +74,6 @@ function buildCurrencyOptions(balances) {
         label: `Combined in ${currency}`,
         scope: 'combined',
         currency,
-        title: `Total equity (Combined in ${currency})`,
       });
     });
   }
@@ -86,7 +85,6 @@ function buildCurrencyOptions(balances) {
         label: currency,
         scope: 'perCurrency',
         currency,
-        title: `Total equity (${currency})`,
       });
     });
   }

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -45,7 +45,7 @@ export default function SummaryMetrics({
   displayTotalEquity,
   usdToCadRate,
 }) {
-  const title = currencyOption?.title || 'Total equity';
+  const title = 'Total equity (Combined in CAD)';
   const totalEquity = balances?.totalEquity ?? null;
   const marketValue = balances?.marketValue ?? null;
   const cash = balances?.cash ?? null;
@@ -132,7 +132,6 @@ SummaryMetrics.propTypes = {
     label: PropTypes.string.isRequired,
     scope: PropTypes.string.isRequired,
     currency: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
   }),
   currencyOptions: PropTypes.arrayOf(
     PropTypes.shape({
@@ -140,7 +139,6 @@ SummaryMetrics.propTypes = {
       label: PropTypes.string.isRequired,
       scope: PropTypes.string.isRequired,
       currency: PropTypes.string.isRequired,
-      title: PropTypes.string.isRequired,
     })
   ).isRequired,
   onCurrencyChange: PropTypes.func.isRequired,


### PR DESCRIPTION
## Summary
- keep the total equity heading fixed to "Total equity (Combined in CAD)"
- remove unused title metadata from currency selection options

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da73fcfdf0832dbee6ed0cf406c6f8