### PR TITLE
Add beneficiary metadata and totals view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ server/node_modules/
 client/dist/
 server/token-store.json
 server/account-names.json
+server/account-beneficiaries.json
 
 # Env files
 *.env

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A local web app that mirrors the Questrade web portal "Summary" tab so you can r
 
      inside the `server` directory. Repeat for every login you want to mirror (for example, `--id=daniel` and `--id=meredith`). When omitted, `--id` defaults to `primary` and updates that entry.
    - Optionally adjust `CLIENT_ORIGIN` or `PORT` if you change the frontend host.
+   - (Optional) Copy `server/account-beneficiaries.example.json` to `server/account-beneficiaries.json` and replace the placeholder account numbers with your own. The proxy reads this file to attach household beneficiary metadata (for example "Eli Bigham" or "Philanthropy") to each account.
    - Copy `client/.env.example` to `client/.env` if you want to point the UI at a non-default proxy URL.
 
 2. Install dependencies
@@ -53,6 +54,7 @@ A local web app that mirrors the Questrade web portal "Summary" tab so you can r
 - Total equity card with today's and open P&L badges, cash, market value, and buying power.
 - Positions table listing symbol, description, account number, intraday/open P&L, quantities, prices, and market value.
 - Manual refresh button to force a new fetch from Questrade.
+- Beneficiaries overlay that converts every account to CAD and totals holdings for each household member.
 - Automatic handling of access-token refresh and persistence of the newest refresh token.
 
 ## Notes & limitations

--- a/client-start.cmd
+++ b/client-start.cmd
@@ -1,0 +1,6 @@
+@echo off
+cd /d "C:\Users\danie\OneDrive\Documents\Investments View\client"
+set "PATH=%ProgramFiles%\nodejs;%PATH%"
+"%ProgramFiles%\nodejs\npm.cmd" run dev
+
+

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -283,6 +283,191 @@ textarea {
   gap: 16px;
 }
 
+.equity-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.equity-card__action-button {
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface-alt);
+  color: var(--color-text-primary);
+  font-weight: 600;
+  font-size: 13px;
+  padding: 8px 16px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.equity-card__action-button:hover:not(:disabled),
+.equity-card__action-button:focus-visible {
+  border-color: var(--color-border-active);
+  color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(24, 163, 122, 0.18);
+  outline: none;
+}
+
+.equity-card__action-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  border-color: var(--color-border);
+  color: var(--color-text-muted);
+  box-shadow: none;
+}
+
+.beneficiaries-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+}
+
+.beneficiaries-dialog {
+  background: var(--color-surface);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
+  max-width: 520px;
+  width: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.beneficiaries-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.beneficiaries-dialog__heading h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.beneficiaries-dialog__subtitle {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.beneficiaries-dialog__timestamp {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.beneficiaries-dialog__close {
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.beneficiaries-dialog__close:hover,
+.beneficiaries-dialog__close:focus-visible {
+  color: var(--color-text-primary);
+  background: var(--color-surface-alt);
+  outline: none;
+}
+
+.beneficiaries-dialog__body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.beneficiaries-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.beneficiaries-list__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.beneficiaries-list__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.beneficiaries-list__name {
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--color-text-primary);
+}
+
+.beneficiaries-list__accounts {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.beneficiaries-list__value {
+  font-weight: 600;
+  font-size: 16px;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.beneficiaries-dialog__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-divider);
+}
+
+.beneficiaries-dialog__total-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.beneficiaries-dialog__total-value {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.beneficiaries-dialog__notice {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.beneficiaries-dialog__empty {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+}
+
 .equity-card__heading {
   display: flex;
   flex-direction: column;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -293,7 +293,7 @@ textarea {
   border: 1px solid var(--color-border-strong);
   background: var(--color-surface-alt);
   color: var(--color-text-primary);
-  font-weight: 600;
+  font-weight: 400;
   font-size: 13px;
   padding: 8px 16px;
   border-radius: var(--radius-pill);
@@ -303,10 +303,12 @@ textarea {
 
 .equity-card__action-button:hover:not(:disabled),
 .equity-card__action-button:focus-visible {
-  border-color: var(--color-border-active);
-  color: var(--color-accent);
-  box-shadow: 0 0 0 3px rgba(24, 163, 122, 0.18);
-  outline: none;
+  border-color: var(--color-border-strong);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  box-shadow: none;
+  outline: 2px solid var(--color-border-strong);
+  outline-offset: 2px;
 }
 
 .equity-card__action-button:disabled {
@@ -921,5 +923,3 @@ button.time-pill:hover .time-pill__icon {
   text-transform: uppercase;
   letter-spacing: 0.03em;
 }
-
-

--- a/client/src/components/AccountSelector.jsx
+++ b/client/src/components/AccountSelector.jsx
@@ -479,6 +479,7 @@ AccountSelector.propTypes = {
       ownerEmail: PropTypes.string,
       loginId: PropTypes.string,
       displayName: PropTypes.string,
+      beneficiary: PropTypes.string,
     })
   ).isRequired,
   selected: PropTypes.string.isRequired,

--- a/client/src/components/BeneficiariesDialog.jsx
+++ b/client/src/components/BeneficiariesDialog.jsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { formatMoney, formatDateTime } from '../utils/formatters';
+
+function formatAccountCount(covered, total) {
+  if (!total && !covered) {
+    return '0 accounts';
+  }
+  const safeTotal = typeof total === 'number' && Number.isFinite(total) ? total : covered;
+  const safeCovered = typeof covered === 'number' && Number.isFinite(covered) ? covered : 0;
+  const plural = safeTotal === 1 ? 'account' : 'accounts';
+  if (safeTotal === safeCovered) {
+    return `${safeCovered} ${plural}`;
+  }
+  return `${safeCovered} of ${safeTotal} ${plural}`;
+}
+
+export default function BeneficiariesDialog({
+  totals,
+  onClose,
+  baseCurrency,
+  isFilteredView,
+  missingAccounts,
+  asOf,
+}) {
+  useEffect(() => {
+    function handleKeyDown(event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const handleOverlayClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  const grandTotal = useMemo(() => {
+    return totals.reduce((acc, entry) => acc + (entry.total || 0), 0);
+  }, [totals]);
+
+  const missingBeneficiaries = useMemo(() => {
+    if (!missingAccounts || missingAccounts.length === 0) {
+      return [];
+    }
+    const names = new Set();
+    missingAccounts.forEach((account) => {
+      if (account?.beneficiary) {
+        names.add(account.beneficiary);
+      }
+    });
+    return Array.from(names);
+  }, [missingAccounts]);
+
+  const hasMissing = missingBeneficiaries.length > 0;
+
+  const noticeMessage = useMemo(() => {
+    if (!hasMissing) {
+      return null;
+    }
+    if (isFilteredView) {
+      return 'Totals reflect only the currently selected account(s). Choose “All accounts” to see the full household.';
+    }
+    if (missingBeneficiaries.length) {
+      return `No balance data was returned for: ${missingBeneficiaries.join(', ')}. Try refreshing to include them.`;
+    }
+    return 'Some accounts did not return balance data in the latest refresh. Try refreshing to include them.';
+  }, [hasMissing, isFilteredView, missingBeneficiaries]);
+
+  return (
+    <div className="beneficiaries-overlay" role="presentation" onClick={handleOverlayClick}>
+      <div
+        className="beneficiaries-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="beneficiaries-dialog-title"
+      >
+        <header className="beneficiaries-dialog__header">
+          <div className="beneficiaries-dialog__heading">
+            <h2 id="beneficiaries-dialog-title">Beneficiaries</h2>
+            <p className="beneficiaries-dialog__subtitle">Totals in {baseCurrency}</p>
+            {asOf && <p className="beneficiaries-dialog__timestamp">As of {formatDateTime(asOf)}</p>}
+          </div>
+          <button type="button" className="beneficiaries-dialog__close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </header>
+
+        {totals.length ? (
+          <div className="beneficiaries-dialog__body">
+            <ul className="beneficiaries-list">
+              {totals.map((entry) => (
+                <li key={entry.beneficiary} className="beneficiaries-list__item">
+                  <div className="beneficiaries-list__info">
+                    <span className="beneficiaries-list__name">{entry.beneficiary}</span>
+                    <span className="beneficiaries-list__accounts">
+                      {formatAccountCount(entry.accountCount, entry.totalAccounts)}
+                    </span>
+                  </div>
+                  <span className="beneficiaries-list__value">{formatMoney(entry.total)}</span>
+                </li>
+              ))}
+            </ul>
+
+            <div className="beneficiaries-dialog__footer">
+              <span className="beneficiaries-dialog__total-label">Household total</span>
+              <span className="beneficiaries-dialog__total-value">{formatMoney(grandTotal)}</span>
+            </div>
+
+            {noticeMessage && (
+              <p className="beneficiaries-dialog__notice" role="note">
+                {noticeMessage}
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="beneficiaries-dialog__empty">
+            No beneficiary totals are available yet. Refresh to pull the latest balances.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const accountShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  number: PropTypes.string,
+  displayName: PropTypes.string,
+  beneficiary: PropTypes.string,
+});
+
+BeneficiariesDialog.propTypes = {
+  totals: PropTypes.arrayOf(
+    PropTypes.shape({
+      beneficiary: PropTypes.string.isRequired,
+      total: PropTypes.number.isRequired,
+      accountCount: PropTypes.number.isRequired,
+      totalAccounts: PropTypes.number.isRequired,
+    })
+  ).isRequired,
+  onClose: PropTypes.func.isRequired,
+  baseCurrency: PropTypes.string.isRequired,
+  isFilteredView: PropTypes.bool,
+  missingAccounts: PropTypes.arrayOf(accountShape),
+  asOf: PropTypes.string,
+};
+
+BeneficiariesDialog.defaultProps = {
+  isFilteredView: false,
+  missingAccounts: [],
+  asOf: null,
+};

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -44,6 +44,8 @@ export default function SummaryMetrics({
   onRefresh,
   displayTotalEquity,
   usdToCadRate,
+  onShowBeneficiaries,
+  beneficiariesDisabled,
 }) {
   const title = 'Total equity (Combined in CAD)';
   const totalEquity = balances?.totalEquity ?? null;
@@ -81,7 +83,19 @@ export default function SummaryMetrics({
             </p>
           )}
         </div>
-        <TimePill asOf={asOf} onRefresh={onRefresh} />
+        <div className="equity-card__actions">
+          {onShowBeneficiaries && (
+            <button
+              type="button"
+              className="equity-card__action-button"
+              onClick={onShowBeneficiaries}
+              disabled={beneficiariesDisabled}
+            >
+              Beneficiaries
+            </button>
+          )}
+          <TimePill asOf={asOf} onRefresh={onRefresh} />
+        </div>
       </header>
 
       {currencyOptions.length > 0 && (
@@ -157,6 +171,8 @@ SummaryMetrics.propTypes = {
   onRefresh: PropTypes.func,
   displayTotalEquity: PropTypes.number,
   usdToCadRate: PropTypes.number,
+  onShowBeneficiaries: PropTypes.func,
+  beneficiariesDisabled: PropTypes.bool,
 };
 
 SummaryMetrics.defaultProps = {
@@ -166,4 +182,6 @@ SummaryMetrics.defaultProps = {
   onRefresh: null,
   displayTotalEquity: null,
   usdToCadRate: null,
+  onShowBeneficiaries: null,
+  beneficiariesDisabled: false,
 };

--- a/server-start.cmd
+++ b/server-start.cmd
@@ -1,0 +1,6 @@
+@echo off
+cd /d "C:\Users\danie\OneDrive\Documents\Investments View\server"
+set "PATH=%ProgramFiles%\nodejs;%PATH%"
+"%ProgramFiles%\nodejs\npm.cmd" start
+
+

--- a/server/account-beneficiaries.example.json
+++ b/server/account-beneficiaries.example.json
@@ -1,0 +1,29 @@
+{
+  "defaultBeneficiary": "Daniel and Meredith Bigham",
+  "overrides": [
+    {
+      "account": "RESP_ACCOUNT_NUMBER",
+      "beneficiary": "Kids"
+    },
+    {
+      "account": "PHILANTHROPY_ACCOUNT_NUMBER",
+      "beneficiary": "Philanthropy"
+    },
+    {
+      "account": "ELI_ACCOUNT_NUMBER",
+      "beneficiary": "Eli Bigham"
+    },
+    {
+      "account": "HAZEL_ACCOUNT_NUMBER",
+      "beneficiary": "Hazel Bigham"
+    },
+    {
+      "account": "OLIVE_ACCOUNT_NUMBER",
+      "beneficiary": "Olive Bigham"
+    },
+    {
+      "account": "EMMA_ACCOUNT_NUMBER",
+      "beneficiary": "Emma Bigham"
+    }
+  ]
+}

--- a/server/src/accountBeneficiaries.js
+++ b/server/src/accountBeneficiaries.js
@@ -1,0 +1,190 @@
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_FILE_NAME = 'account-beneficiaries.json';
+
+const beneficiariesFilePath = (() => {
+  const configured = process.env.ACCOUNT_BENEFICIARIES_FILE;
+  if (!configured) {
+    return path.join(process.cwd(), DEFAULT_FILE_NAME);
+  }
+  if (path.isAbsolute(configured)) {
+    return configured;
+  }
+  return path.join(process.cwd(), configured);
+})();
+
+let cachedBeneficiaries = { overrides: Object.create(null), defaultBeneficiary: null };
+let cachedMarker = null;
+let hasLoggedError = false;
+
+function createMarker(stats) {
+  if (!stats) {
+    return null;
+  }
+  return String(stats.size) + ':' + String(stats.mtimeMs);
+}
+
+function applyBeneficiary(target, key, beneficiary) {
+  if (!key || !beneficiary) {
+    return;
+  }
+  const normalizedKey = String(key).trim();
+  if (!normalizedKey) {
+    return;
+  }
+  const normalizedValue = String(beneficiary).trim();
+  if (!normalizedValue) {
+    return;
+  }
+  const lookupKey = normalizedKey.toLowerCase();
+  target[lookupKey] = normalizedValue;
+  const condensed = normalizedKey.replace(/\s+/g, '');
+  if (condensed && condensed.toLowerCase() !== lookupKey) {
+    target[condensed.toLowerCase()] = normalizedValue;
+  }
+}
+
+function extractEntry(target, entry, fallbackKey) {
+  if (entry === null || entry === undefined) {
+    return;
+  }
+  if (typeof entry === 'string') {
+    if (fallbackKey) {
+      applyBeneficiary(target, fallbackKey, entry);
+    }
+    return;
+  }
+  if (typeof entry !== 'object') {
+    return;
+  }
+
+  const candidateBeneficiary =
+    entry.beneficiary ?? entry.value ?? entry.name ?? entry.label ?? entry.display ?? entry.target;
+
+  const candidateKey =
+    entry.account ??
+    entry.number ??
+    entry.accountNumber ??
+    entry.id ??
+    entry.key ??
+    entry.accountId ??
+    entry.identifier ??
+    entry.match ??
+    fallbackKey;
+
+  const candidateDisplay = entry.displayName ?? entry.title ?? entry.alias ?? entry.description ?? null;
+
+  if (candidateKey !== undefined && candidateBeneficiary !== undefined) {
+    applyBeneficiary(target, candidateKey, candidateBeneficiary);
+  }
+
+  if (candidateDisplay !== undefined && candidateBeneficiary !== undefined) {
+    applyBeneficiary(target, candidateDisplay, candidateBeneficiary);
+  }
+}
+
+function collectOverrides(target, container) {
+  if (!container) {
+    return;
+  }
+  if (Array.isArray(container)) {
+    container.forEach((entry) => {
+      extractEntry(target, entry, undefined);
+    });
+    return;
+  }
+  if (typeof container !== 'object') {
+    return;
+  }
+  Object.keys(container).forEach((key) => {
+    const value = container[key];
+    if (key === 'default' || key === 'defaultBeneficiary' || key === 'defaults') {
+      return;
+    }
+    if (typeof value === 'string') {
+      applyBeneficiary(target, key, value);
+      return;
+    }
+    extractEntry(target, value, key);
+  });
+}
+
+function normalizeBeneficiaries(raw) {
+  const overrides = Object.create(null);
+  if (!raw || typeof raw !== 'object') {
+    return { overrides, defaultBeneficiary: null };
+  }
+
+  const defaultCandidate =
+    raw.defaultBeneficiary ?? raw.default ?? (raw.defaults && raw.defaults.beneficiary) ?? null;
+  const defaultBeneficiary =
+    typeof defaultCandidate === 'string' && defaultCandidate.trim() ? defaultCandidate.trim() : null;
+
+  const containers = [];
+  if (Array.isArray(raw)) {
+    containers.push(raw);
+  } else {
+    containers.push(raw);
+    const nestedKeys = ['accounts', 'overrides', 'items', 'entries'];
+    nestedKeys.forEach((key) => {
+      if (raw[key]) {
+        containers.push(raw[key]);
+      }
+    });
+  }
+
+  containers.forEach((container) => {
+    collectOverrides(overrides, container);
+  });
+
+  return { overrides, defaultBeneficiary };
+}
+
+function loadBeneficiaries() {
+  if (!beneficiariesFilePath) {
+    cachedBeneficiaries = { overrides: Object.create(null), defaultBeneficiary: null };
+    cachedMarker = null;
+    return cachedBeneficiaries;
+  }
+  if (!fs.existsSync(beneficiariesFilePath)) {
+    cachedBeneficiaries = { overrides: Object.create(null), defaultBeneficiary: null };
+    cachedMarker = null;
+    hasLoggedError = false;
+    return cachedBeneficiaries;
+  }
+  const stats = fs.statSync(beneficiariesFilePath);
+  const marker = createMarker(stats);
+  if (marker && marker === cachedMarker) {
+    return cachedBeneficiaries;
+  }
+  const content = fs.readFileSync(beneficiariesFilePath, 'utf-8').replace(/^\uFEFF/, '');
+  if (!content.trim()) {
+    cachedBeneficiaries = { overrides: Object.create(null), defaultBeneficiary: null };
+    cachedMarker = marker;
+    hasLoggedError = false;
+    return cachedBeneficiaries;
+  }
+  const parsed = JSON.parse(content);
+  cachedBeneficiaries = normalizeBeneficiaries(parsed);
+  cachedMarker = marker;
+  hasLoggedError = false;
+  return cachedBeneficiaries;
+}
+
+function getAccountBeneficiaries() {
+  try {
+    return loadBeneficiaries();
+  } catch (error) {
+    if (!hasLoggedError) {
+      console.warn('Failed to load account beneficiary overrides from ' + beneficiariesFilePath + ':', error.message);
+      hasLoggedError = true;
+    }
+    return cachedBeneficiaries || { overrides: Object.create(null), defaultBeneficiary: null };
+  }
+}
+
+module.exports = {
+  getAccountBeneficiaries,
+  accountBeneficiariesFilePath: beneficiariesFilePath,
+};


### PR DESCRIPTION
## Summary
- add a beneficiary override loader on the server and include per-account balance summaries in the summary payload
- document and scaffold beneficiary configuration plus wire beneficiaries onto account metadata
- expose a Beneficiaries overlay in the client to show CAD totals per household member with new UI styles

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68da7a032bfc832d84e645c39a15ab31