### PR TITLE
Add beneficiary P&L metrics to dialog

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -442,6 +442,56 @@ textarea {
   font-variant-numeric: tabular-nums;
 }
 
+.beneficiaries-list__metrics {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.beneficiaries-list__pnl-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-end;
+}
+
+.beneficiaries-list__pnl-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-end;
+  gap: 8px;
+  font-variant-numeric: tabular-nums;
+}
+
+.beneficiaries-list__pnl-label {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.beneficiaries-list__pnl-value {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.beneficiaries-list__pnl-value--positive {
+  color: var(--color-accent);
+}
+
+.beneficiaries-list__pnl-value--negative {
+  color: var(--color-negative);
+}
+
+.beneficiaries-list__pnl-value--neutral {
+  color: var(--color-text-primary);
+}
+
+.beneficiaries-list__pnl-extra {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
 .beneficiaries-dialog__footer {
   display: flex;
   justify-content: space-between;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -413,7 +413,13 @@ textarea {
 
 .beneficiaries-list__item {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.beneficiaries-list__header {
+  display: flex;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
 }
@@ -422,6 +428,8 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  flex: 1;
+  min-width: 0;
 }
 
 .beneficiaries-list__name {
@@ -442,24 +450,17 @@ textarea {
   font-variant-numeric: tabular-nums;
 }
 
-.beneficiaries-list__metrics {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 6px;
-}
-
 .beneficiaries-list__pnl-group {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  align-items: flex-end;
+  align-items: flex-start;
 }
 
 .beneficiaries-list__pnl-row {
   display: flex;
   align-items: baseline;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 8px;
   font-variant-numeric: tabular-nums;
 }

--- a/client/src/components/BeneficiariesDialog.jsx
+++ b/client/src/components/BeneficiariesDialog.jsx
@@ -129,37 +129,37 @@ export default function BeneficiariesDialog({
 
                 return (
                   <li key={entry.beneficiary} className="beneficiaries-list__item">
-                    <div className="beneficiaries-list__info">
-                      <span className="beneficiaries-list__name">{entry.beneficiary}</span>
-                      <span className="beneficiaries-list__accounts">
-                        {formatAccountCount(entry.accountCount, entry.totalAccounts)}
-                      </span>
-                    </div>
-                    <div className="beneficiaries-list__metrics">
+                    <div className="beneficiaries-list__header">
+                      <div className="beneficiaries-list__info">
+                        <span className="beneficiaries-list__name">{entry.beneficiary}</span>
+                        <span className="beneficiaries-list__accounts">
+                          {formatAccountCount(entry.accountCount, entry.totalAccounts)}
+                        </span>
+                      </div>
                       <span className="beneficiaries-list__value">{formatMoney(entry.total)}</span>
-                      <div className="beneficiaries-list__pnl-group">
-                        <div className="beneficiaries-list__pnl-row">
-                          <span className="beneficiaries-list__pnl-label">Today's P&amp;L</span>
-                          <span
-                            className={`beneficiaries-list__pnl-value beneficiaries-list__pnl-value--${todayTone}`}
-                          >
-                            {todayFormatted}
-                          </span>
-                          {todayPercent && (
-                            <span className="beneficiaries-list__pnl-extra">({todayPercent})</span>
-                          )}
-                        </div>
-                        <div className="beneficiaries-list__pnl-row">
-                          <span className="beneficiaries-list__pnl-label">Open P&amp;L</span>
-                          <span
-                            className={`beneficiaries-list__pnl-value beneficiaries-list__pnl-value--${openTone}`}
-                          >
-                            {openFormatted}
-                          </span>
-                          {openPercent && (
-                            <span className="beneficiaries-list__pnl-extra">({openPercent})</span>
-                          )}
-                        </div>
+                    </div>
+                    <div className="beneficiaries-list__pnl-group">
+                      <div className="beneficiaries-list__pnl-row">
+                        <span className="beneficiaries-list__pnl-label">Today's P&amp;L</span>
+                        <span
+                          className={`beneficiaries-list__pnl-value beneficiaries-list__pnl-value--${todayTone}`}
+                        >
+                          {todayFormatted}
+                        </span>
+                        {todayPercent && (
+                          <span className="beneficiaries-list__pnl-extra">({todayPercent})</span>
+                        )}
+                      </div>
+                      <div className="beneficiaries-list__pnl-row">
+                        <span className="beneficiaries-list__pnl-label">Open P&amp;L</span>
+                        <span
+                          className={`beneficiaries-list__pnl-value beneficiaries-list__pnl-value--${openTone}`}
+                        >
+                          {openFormatted}
+                        </span>
+                        {openPercent && (
+                          <span className="beneficiaries-list__pnl-extra">({openPercent})</span>
+                        )}
                       </div>
                     </div>
                   </li>

--- a/client/src/components/BeneficiariesDialog.jsx
+++ b/client/src/components/BeneficiariesDialog.jsx
@@ -1,6 +1,12 @@
 import { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { formatMoney, formatDateTime } from '../utils/formatters';
+import {
+  formatMoney,
+  formatDateTime,
+  formatSignedMoney,
+  formatSignedPercent,
+  classifyPnL,
+} from '../utils/formatters';
 
 function formatAccountCount(covered, total) {
   if (!total && !covered) {
@@ -43,6 +49,25 @@ export default function BeneficiariesDialog({
   const grandTotal = useMemo(() => {
     return totals.reduce((acc, entry) => acc + (entry.total || 0), 0);
   }, [totals]);
+
+  const percentOptions = useMemo(
+    () => ({ minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+    []
+  );
+
+  const formatPercentChange = (pnlValue, totalValue) => {
+    if (typeof pnlValue !== 'number' || Number.isNaN(pnlValue)) {
+      return null;
+    }
+    if (typeof totalValue !== 'number' || totalValue === 0) {
+      return null;
+    }
+    const percent = (pnlValue / totalValue) * 100;
+    if (!Number.isFinite(percent)) {
+      return null;
+    }
+    return formatSignedPercent(percent, percentOptions);
+  };
 
   const missingBeneficiaries = useMemo(() => {
     if (!missingAccounts || missingAccounts.length === 0) {
@@ -94,17 +119,52 @@ export default function BeneficiariesDialog({
         {totals.length ? (
           <div className="beneficiaries-dialog__body">
             <ul className="beneficiaries-list">
-              {totals.map((entry) => (
-                <li key={entry.beneficiary} className="beneficiaries-list__item">
-                  <div className="beneficiaries-list__info">
-                    <span className="beneficiaries-list__name">{entry.beneficiary}</span>
-                    <span className="beneficiaries-list__accounts">
-                      {formatAccountCount(entry.accountCount, entry.totalAccounts)}
-                    </span>
-                  </div>
-                  <span className="beneficiaries-list__value">{formatMoney(entry.total)}</span>
-                </li>
-              ))}
+              {totals.map((entry) => {
+                const todayTone = classifyPnL(entry.dayPnl);
+                const openTone = classifyPnL(entry.openPnl);
+                const todayFormatted = formatSignedMoney(entry.dayPnl);
+                const openFormatted = formatSignedMoney(entry.openPnl);
+                const todayPercent = formatPercentChange(entry.dayPnl, entry.total);
+                const openPercent = formatPercentChange(entry.openPnl, entry.total);
+
+                return (
+                  <li key={entry.beneficiary} className="beneficiaries-list__item">
+                    <div className="beneficiaries-list__info">
+                      <span className="beneficiaries-list__name">{entry.beneficiary}</span>
+                      <span className="beneficiaries-list__accounts">
+                        {formatAccountCount(entry.accountCount, entry.totalAccounts)}
+                      </span>
+                    </div>
+                    <div className="beneficiaries-list__metrics">
+                      <span className="beneficiaries-list__value">{formatMoney(entry.total)}</span>
+                      <div className="beneficiaries-list__pnl-group">
+                        <div className="beneficiaries-list__pnl-row">
+                          <span className="beneficiaries-list__pnl-label">Today's P&amp;L</span>
+                          <span
+                            className={`beneficiaries-list__pnl-value beneficiaries-list__pnl-value--${todayTone}`}
+                          >
+                            {todayFormatted}
+                          </span>
+                          {todayPercent && (
+                            <span className="beneficiaries-list__pnl-extra">({todayPercent})</span>
+                          )}
+                        </div>
+                        <div className="beneficiaries-list__pnl-row">
+                          <span className="beneficiaries-list__pnl-label">Open P&amp;L</span>
+                          <span
+                            className={`beneficiaries-list__pnl-value beneficiaries-list__pnl-value--${openTone}`}
+                          >
+                            {openFormatted}
+                          </span>
+                          {openPercent && (
+                            <span className="beneficiaries-list__pnl-extra">({openPercent})</span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
             </ul>
 
             <div className="beneficiaries-dialog__footer">
@@ -140,6 +200,8 @@ BeneficiariesDialog.propTypes = {
     PropTypes.shape({
       beneficiary: PropTypes.string.isRequired,
       total: PropTypes.number.isRequired,
+      dayPnl: PropTypes.number.isRequired,
+      openPnl: PropTypes.number.isRequired,
       accountCount: PropTypes.number.isRequired,
       totalAccounts: PropTypes.number.isRequired,
     })


### PR DESCRIPTION
## Summary
- compute per-beneficiary day and open P&L in the app state and expose it to the dialog
- extend the beneficiaries dialog to render formatted P&L values with tone-aware styling and percentages
- add CSS styling for the new P&L rows so they match the summary metrics presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da8b7e2fb8832da978805eca68924b