### PR TITLE
Add P&L heatmap dialog for summary metrics

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -589,6 +589,27 @@ textarea {
   border-bottom: 1px dotted var(--color-border-strong);
 }
 
+.equity-card__metric-row[data-interactive='true'] {
+  cursor: pointer;
+  border-bottom-style: solid;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  border-radius: 8px;
+  margin: 0 -12px;
+  padding: 12px;
+}
+
+.equity-card__metric-row[data-interactive='true']:hover {
+  background: var(--color-surface-alt);
+  box-shadow: inset 0 0 0 1px var(--color-border);
+}
+
+.equity-card__metric-row[data-interactive='true']:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  background: var(--color-surface-alt);
+  box-shadow: inset 0 0 0 1px var(--color-accent);
+}
+
 .equity-card__metric-column .equity-card__metric-row:first-child {
   padding-top: 0;
 }
@@ -634,6 +655,162 @@ textarea {
 .equity-card__metric-extra {
   font-size: 13px;
   color: var(--color-text-muted);
+}
+
+.pnl-heatmap-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1100;
+}
+
+.pnl-heatmap-dialog {
+  background: var(--color-surface);
+  border-radius: 20px;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+  width: min(1100px, 94vw);
+  height: min(760px, 94vh);
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+}
+
+.pnl-heatmap-dialog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.pnl-heatmap-dialog__heading h2 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.pnl-heatmap-dialog__subtitle {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.pnl-heatmap-dialog__timestamp {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.pnl-heatmap-dialog__close {
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.pnl-heatmap-dialog__close:hover,
+.pnl-heatmap-dialog__close:focus-visible {
+  color: var(--color-text-primary);
+  background: var(--color-surface-alt);
+  outline: none;
+}
+
+.pnl-heatmap-dialog__body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.pnl-heatmap-board {
+  position: relative;
+  flex: 1;
+  border-radius: 16px;
+  background: var(--color-surface-alt);
+  overflow: hidden;
+  min-height: 360px;
+}
+
+.pnl-heatmap-board__tile {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 12px;
+  border-radius: 12px;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.1);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  overflow: hidden;
+}
+
+.pnl-heatmap-board__tile:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.18);
+}
+
+.pnl-heatmap-board__tile-header,
+.pnl-heatmap-board__tile-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.pnl-heatmap-board__symbol {
+  font-weight: 600;
+  font-size: 16px;
+  letter-spacing: 0.02em;
+}
+
+.pnl-heatmap-board__share {
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+.pnl-heatmap-board__value {
+  font-weight: 600;
+  font-size: 18px;
+  font-variant-numeric: tabular-nums;
+}
+
+.pnl-heatmap-board__percent {
+  font-size: 13px;
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.pnl-heatmap-empty {
+  margin: auto;
+  font-size: 15px;
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 768px) {
+  .pnl-heatmap-dialog {
+    width: min(95vw, 640px);
+    height: min(90vh, 640px);
+    padding: 20px;
+    border-radius: 16px;
+  }
+
+  .pnl-heatmap-board__symbol {
+    font-size: 14px;
+  }
+
+  .pnl-heatmap-board__value {
+    font-size: 16px;
+  }
 }
 
 .positions-card {

--- a/client/src/components/PnlHeatmapDialog.jsx
+++ b/client/src/components/PnlHeatmapDialog.jsx
@@ -1,0 +1,311 @@
+import { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import {
+  formatDateTime,
+  formatMoney,
+  formatPercent,
+  formatSignedMoney,
+  formatSignedPercent,
+} from '../utils/formatters';
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function buildTreemapLayout(items, orientation = 'vertical', origin = { x: 0, y: 0, width: 1, height: 1 }) {
+  if (!items.length) {
+    return [];
+  }
+
+  if (items.length === 1) {
+    const [item] = items;
+    return [
+      {
+        ...item,
+        x: origin.x,
+        y: origin.y,
+        width: origin.width,
+        height: origin.height,
+      },
+    ];
+  }
+
+  const totalWeight = items.reduce((sum, item) => sum + item.weight, 0);
+  if (totalWeight <= 0) {
+    return items.map((item) => ({ ...item, x: origin.x, y: origin.y, width: origin.width, height: origin.height }));
+  }
+
+  let splitIndex = 0;
+  let running = 0;
+  const target = totalWeight / 2;
+
+  while (splitIndex < items.length) {
+    running += items[splitIndex].weight;
+    splitIndex += 1;
+    if (running >= target) {
+      break;
+    }
+  }
+
+  if (splitIndex <= 0) {
+    splitIndex = 1;
+  } else if (splitIndex >= items.length) {
+    splitIndex = items.length - 1;
+  }
+
+  const firstGroup = items.slice(0, splitIndex);
+  const secondGroup = items.slice(splitIndex);
+  const firstWeight = firstGroup.reduce((sum, item) => sum + item.weight, 0);
+
+  if (orientation === 'vertical') {
+    const firstWidth = origin.width * (firstWeight / totalWeight);
+    const secondWidth = origin.width - firstWidth;
+    return [
+      ...buildTreemapLayout(firstGroup, 'horizontal', {
+        x: origin.x,
+        y: origin.y,
+        width: firstWidth,
+        height: origin.height,
+      }),
+      ...buildTreemapLayout(secondGroup, 'horizontal', {
+        x: origin.x + firstWidth,
+        y: origin.y,
+        width: secondWidth,
+        height: origin.height,
+      }),
+    ];
+  }
+
+  const firstHeight = origin.height * (firstWeight / totalWeight);
+  const secondHeight = origin.height - firstHeight;
+  return [
+    ...buildTreemapLayout(firstGroup, 'vertical', {
+      x: origin.x,
+      y: origin.y,
+      width: origin.width,
+      height: firstHeight,
+    }),
+    ...buildTreemapLayout(secondGroup, 'vertical', {
+      x: origin.x,
+      y: origin.y + firstHeight,
+      width: origin.width,
+      height: secondHeight,
+    }),
+  ];
+}
+
+function resolveOrientation(width, height) {
+  if (width >= height) {
+    return 'vertical';
+  }
+  return 'horizontal';
+}
+
+function buildHeatmapNodes(positions, metricKey) {
+  const filtered = positions
+    .filter((position) => isFiniteNumber(position.normalizedMarketValue) && position.normalizedMarketValue > 0)
+    .map((position) => ({
+      id: position.rowId || position.symbol || position.symbolId || String(position.id || position.symbol || Math.random()),
+      symbol: position.symbol || position.symbolId || '—',
+      description: position.description || null,
+      weight: position.normalizedMarketValue,
+      share: isFiniteNumber(position.portfolioShare) ? position.portfolioShare : null,
+      metricValue: isFiniteNumber(position[metricKey]) ? position[metricKey] : 0,
+      marketValue: position.normalizedMarketValue,
+    }));
+
+  if (!filtered.length) {
+    return [];
+  }
+
+  const sorted = filtered.slice().sort((a, b) => b.weight - a.weight);
+  const layoutOrientation = resolveOrientation(1, 1);
+  const layout = buildTreemapLayout(sorted, layoutOrientation);
+  const gutter = 0.004;
+
+  return layout.map((node) => {
+    const adjustedWidth = Math.max(0, node.width - gutter * 2);
+    const adjustedHeight = Math.max(0, node.height - gutter * 2);
+    return {
+      ...node,
+      x: node.x + gutter,
+      y: node.y + gutter,
+      width: adjustedWidth,
+      height: adjustedHeight,
+    };
+  });
+}
+
+function resolveTileColor(value, intensity) {
+  if (value > 0) {
+    const hue = 142;
+    const saturation = 45 + intensity * 35;
+    const lightness = 82 - intensity * 40;
+    return `hsl(${hue}, ${clamp(saturation, 40, 85)}%, ${clamp(lightness, 30, 82)}%)`;
+  }
+  if (value < 0) {
+    const hue = 0;
+    const saturation = 50 + intensity * 35;
+    const lightness = 82 - intensity * 40;
+    return `hsl(${hue}, ${clamp(saturation, 45, 90)}%, ${clamp(lightness, 28, 82)}%)`;
+  }
+  return 'hsl(215, 20%, 92%)';
+}
+
+function resolveTextColor(intensity, value) {
+  if (value === 0) {
+    return 'var(--color-text-primary)';
+  }
+  if (intensity >= 0.4) {
+    return 'rgba(255, 255, 255, 0.96)';
+  }
+  return 'var(--color-text-primary)';
+}
+
+export default function PnlHeatmapDialog({
+  positions,
+  mode,
+  onClose,
+  baseCurrency,
+  asOf,
+}) {
+  const metricKey = mode === 'open' ? 'openPnl' : 'dayPnl';
+  const metricLabel = mode === 'open' ? 'Open P&L' : "Today's P&L";
+
+  const nodes = useMemo(() => buildHeatmapNodes(positions, metricKey), [positions, metricKey]);
+
+  const totals = useMemo(() => {
+    if (!positions.length) {
+      return { marketValue: 0, pnl: 0 };
+    }
+    return positions.reduce(
+      (acc, position) => {
+        const marketValue = isFiniteNumber(position.normalizedMarketValue) ? position.normalizedMarketValue : 0;
+        const pnlValue = isFiniteNumber(position[metricKey]) ? position[metricKey] : 0;
+        return {
+          marketValue: acc.marketValue + marketValue,
+          pnl: acc.pnl + pnlValue,
+        };
+      },
+      { marketValue: 0, pnl: 0 }
+    );
+  }, [positions, metricKey]);
+
+  const maxMagnitude = useMemo(() => {
+    if (!nodes.length) {
+      return 0;
+    }
+    return nodes.reduce((acc, node) => Math.max(acc, Math.abs(node.metricValue)), 0);
+  }, [nodes]);
+
+  const asOfDisplay = asOf ? `As of ${formatDateTime(asOf)}` : null;
+  const normalizedCurrency = typeof baseCurrency === 'string' && baseCurrency.trim()
+    ? baseCurrency.trim().toUpperCase()
+    : null;
+  const pnlLabel = normalizedCurrency
+    ? `${formatSignedMoney(totals.pnl)} ${normalizedCurrency}`
+    : formatSignedMoney(totals.pnl);
+  const marketValueLabel = normalizedCurrency
+    ? `${formatMoney(totals.marketValue)} ${normalizedCurrency}`
+    : formatMoney(totals.marketValue);
+
+  return (
+    <div className="pnl-heatmap-overlay" role="presentation">
+      <div
+        className="pnl-heatmap-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="pnl-heatmap-title"
+      >
+        <header className="pnl-heatmap-dialog__header">
+          <div className="pnl-heatmap-dialog__heading">
+            <h2 id="pnl-heatmap-title">{metricLabel} breakdown</h2>
+            <p className="pnl-heatmap-dialog__subtitle">
+              {pnlLabel} in {marketValueLabel} total market value
+            </p>
+            {asOfDisplay && <p className="pnl-heatmap-dialog__timestamp">{asOfDisplay}</p>}
+          </div>
+          <button type="button" className="pnl-heatmap-dialog__close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </header>
+        <div className="pnl-heatmap-dialog__body">
+          {nodes.length ? (
+            <div className="pnl-heatmap-board" role="presentation">
+              {nodes.map((node) => {
+                const intensity = maxMagnitude > 0 ? Math.min(1, Math.abs(node.metricValue) / maxMagnitude) : 0;
+                const backgroundColor = resolveTileColor(node.metricValue, intensity);
+                const textColor = resolveTextColor(intensity, node.metricValue);
+                const pnlDisplay = formatSignedMoney(node.metricValue);
+                const shareLabel = node.share !== null ? formatPercent(node.share, { minimumFractionDigits: 1, maximumFractionDigits: 1 }) : null;
+                const changePercent = node.marketValue > 0 ? node.metricValue / node.marketValue : null;
+                const percentDisplay = isFiniteNumber(changePercent)
+                  ? formatSignedPercent(changePercent * 100, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+                  : null;
+
+                return (
+                  <div
+                    key={node.id}
+                    className="pnl-heatmap-board__tile"
+                    style={{
+                      left: `${node.x * 100}%`,
+                      top: `${node.y * 100}%`,
+                      width: `${node.width * 100}%`,
+                      height: `${node.height * 100}%`,
+                      backgroundColor,
+                      color: textColor,
+                    }}
+                    title={`${node.symbol}\n${metricLabel}: ${pnlDisplay}${
+                      percentDisplay ? ` (${percentDisplay})` : ''
+                    }${shareLabel ? `\nPortfolio share: ${shareLabel}` : ''}`}
+                  >
+                    <div className="pnl-heatmap-board__tile-header">
+                      <span className="pnl-heatmap-board__symbol">{node.symbol}</span>
+                      {shareLabel && <span className="pnl-heatmap-board__share">{shareLabel}</span>}
+                    </div>
+                    <div className="pnl-heatmap-board__tile-footer">
+                      <span className="pnl-heatmap-board__value">{pnlDisplay}</span>
+                      {percentDisplay && (
+                        <span className="pnl-heatmap-board__percent">{percentDisplay}</span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="pnl-heatmap-empty">No positions available for this view.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+PnlHeatmapDialog.propTypes = {
+  positions: PropTypes.arrayOf(
+    PropTypes.shape({
+      symbol: PropTypes.string,
+      symbolId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      description: PropTypes.string,
+      dayPnl: PropTypes.number,
+      openPnl: PropTypes.number,
+      normalizedMarketValue: PropTypes.number,
+      portfolioShare: PropTypes.number,
+      rowId: PropTypes.string,
+    })
+  ).isRequired,
+  mode: PropTypes.oneOf(['day', 'open']).isRequired,
+  onClose: PropTypes.func.isRequired,
+  baseCurrency: PropTypes.string,
+  asOf: PropTypes.string,
+};
+
+PnlHeatmapDialog.defaultProps = {
+  baseCurrency: 'CAD',
+  asOf: null,
+};

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -8,10 +8,32 @@ import {
   formatSignedPercent,
 } from '../utils/formatters';
 
-function MetricRow({ label, value, extra, tone, className }) {
+function MetricRow({ label, value, extra, tone, className, onActivate }) {
   const rowClass = className ? `equity-card__metric-row ${className}` : 'equity-card__metric-row';
+  const interactive = typeof onActivate === 'function';
+
+  const handleKeyDown = (event) => {
+    if (!interactive) {
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onActivate();
+    }
+  };
+
+  const interactiveProps = interactive
+    ? {
+        role: 'button',
+        tabIndex: 0,
+        onClick: onActivate,
+        onKeyDown: handleKeyDown,
+        'data-interactive': 'true',
+      }
+    : {};
+
   return (
-    <div className={rowClass}>
+    <div className={rowClass} {...interactiveProps}>
       <dt>{label}</dt>
       <dd>
         <span className={`equity-card__metric-value equity-card__metric-value--${tone}`}>{value}</span>
@@ -27,11 +49,13 @@ MetricRow.propTypes = {
   extra: PropTypes.node,
   tone: PropTypes.oneOf(['positive', 'negative', 'neutral']).isRequired,
   className: PropTypes.string,
+  onActivate: PropTypes.func,
 };
 
 MetricRow.defaultProps = {
   extra: null,
   className: '',
+  onActivate: null,
 };
 
 export default function SummaryMetrics({
@@ -46,6 +70,7 @@ export default function SummaryMetrics({
   usdToCadRate,
   onShowBeneficiaries,
   beneficiariesDisabled,
+  onShowPnlBreakdown,
 }) {
   const title = 'Total equity (Combined in CAD)';
   const totalEquity = balances?.totalEquity ?? null;
@@ -124,8 +149,14 @@ export default function SummaryMetrics({
             value={formattedToday}
             extra={dayPercent ? `(${dayPercent})` : null}
             tone={todayTone}
+            onActivate={onShowPnlBreakdown ? () => onShowPnlBreakdown('day') : null}
           />
-          <MetricRow label="Open P&L" value={formattedOpen} tone={openTone} />
+          <MetricRow
+            label="Open P&L"
+            value={formattedOpen}
+            tone={openTone}
+            onActivate={onShowPnlBreakdown ? () => onShowPnlBreakdown('open') : null}
+          />
           <MetricRow label="Total P&L" value={formattedTotal} tone={totalTone} />
         </dl>
         <dl className="equity-card__metric-column">
@@ -173,6 +204,7 @@ SummaryMetrics.propTypes = {
   usdToCadRate: PropTypes.number,
   onShowBeneficiaries: PropTypes.func,
   beneficiariesDisabled: PropTypes.bool,
+  onShowPnlBreakdown: PropTypes.func,
 };
 
 SummaryMetrics.defaultProps = {
@@ -184,4 +216,5 @@ SummaryMetrics.defaultProps = {
   usdToCadRate: null,
   onShowBeneficiaries: null,
   beneficiariesDisabled: false,
+  onShowPnlBreakdown: null,
 };


### PR DESCRIPTION
## Summary
- make the "Today's P&L" and "Open P&L" metrics interactive so they can reveal additional detail
- add a treemap-based P&L heatmap dialog that visualizes symbol performance and portfolio share
- style the summary metrics and new dialog for accessibility, hover/focus feedback, and responsive layouts

## Testing
- npm run lint (warns about a pre-existing react-hooks dependency warning)


------
https://chatgpt.com/codex/tasks/task_e_68da92ba6130832d8494b199279dd5ae