### PR TITLE
Show alternate PnL tooltip values

### DIFF
--- a/client/src/components/PositionsTable.jsx
+++ b/client/src/components/PositionsTable.jsx
@@ -169,11 +169,13 @@ function compareRows(header, direction, accessorOverride) {
 function PnlBadge({ value, percent, mode, onToggle }) {
   const tone = classifyPnL(value);
   const isPercentMode = mode === 'percent';
-  const formatted = isPercentMode
-    ? percent !== null && Number.isFinite(percent)
-      ? formatSignedPercent(percent, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-      : '\u2014'
-    : formatSignedMoney(value);
+  const hasPercent = percent !== null && Number.isFinite(percent);
+  const formattedPercent = hasPercent
+    ? formatSignedPercent(percent, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+    : '\u2014';
+  const formattedCurrency = formatSignedMoney(value);
+  const formatted = isPercentMode ? formattedPercent : formattedCurrency;
+  const tooltip = isPercentMode ? formattedCurrency : formattedPercent;
 
   return (
     <button
@@ -181,7 +183,7 @@ function PnlBadge({ value, percent, mode, onToggle }) {
       className={`positions-table__pnl ${tone}`}
       onClick={onToggle}
       aria-pressed={isPercentMode}
-      title={isPercentMode ? 'Show dollar values' : 'Show percentage values'}
+      title={tooltip}
     >
       {formatted}
     </button>


### PR DESCRIPTION
## Summary
- show the alternate PnL value in the tooltip so hovering reveals the other mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab63e67b8832db1e4993fd3112e65