### PR TITLE
Keep refresh content visible and animate button

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -581,6 +581,11 @@ textarea {
   transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
 }
 
+.time-pill--refreshing {
+  justify-content: center;
+  gap: 0;
+}
+
 
 
 
@@ -591,6 +596,19 @@ textarea {
   background-position: center;
   background-size: 14px 14px;
   background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M0%200h24v24H0Z%22%20fill%3D%22none%22%2F%3E%3Cpath%20d%3D%22M17.65%206.35A8%208%200%201%200%2019.73%2014h-2.08A6%206%200%201%201%2012%206a5.92%205.92%200%200%201%204.22%201.78L13%2011h7V4Z%22%20fill%3D%22%236b7787%22%2F%3E%3C%2Fsvg%3E");
+}
+
+.time-pill--refreshing .time-pill__icon {
+  animation: time-pill-spin 1s linear infinite;
+}
+
+@keyframes time-pill-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 .equity-card__chip-row {
   display: inline-flex;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1011,13 +1011,15 @@ export default function App() {
     return DEFAULT_POSITIONS_SORT.direction;
   })();
 
-  const showContent = Boolean(data) && !loading;
+  const hasData = Boolean(data);
+  const isRefreshing = loading && hasData;
+  const showContent = hasData;
 
   useEffect(() => {
-    if (!showContent && pnlBreakdownMode) {
+    if (!hasData && pnlBreakdownMode) {
       setPnlBreakdownMode(null);
     }
-  }, [showContent, pnlBreakdownMode]);
+  }, [hasData, pnlBreakdownMode]);
 
   const handleRefresh = () => {
     setRefreshKey((value) => value + 1);
@@ -1092,6 +1094,7 @@ export default function App() {
             onShowBeneficiaries={handleOpenBeneficiaries}
             beneficiariesDisabled={beneficiariesDisabled}
             onShowPnlBreakdown={orderedPositions.length ? handleShowPnlBreakdown : null}
+            isRefreshing={isRefreshing}
           />
         )}
 

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -71,6 +71,7 @@ export default function SummaryMetrics({
   onShowBeneficiaries,
   beneficiariesDisabled,
   onShowPnlBreakdown,
+  isRefreshing,
 }) {
   const title = 'Total equity (Combined in CAD)';
   const totalEquity = balances?.totalEquity ?? null;
@@ -119,7 +120,7 @@ export default function SummaryMetrics({
               Beneficiaries
             </button>
           )}
-          <TimePill asOf={asOf} onRefresh={onRefresh} />
+          <TimePill asOf={asOf} onRefresh={onRefresh} refreshing={isRefreshing} />
         </div>
       </header>
 
@@ -205,6 +206,7 @@ SummaryMetrics.propTypes = {
   onShowBeneficiaries: PropTypes.func,
   beneficiariesDisabled: PropTypes.bool,
   onShowPnlBreakdown: PropTypes.func,
+  isRefreshing: PropTypes.bool,
 };
 
 SummaryMetrics.defaultProps = {
@@ -217,4 +219,5 @@ SummaryMetrics.defaultProps = {
   onShowBeneficiaries: null,
   beneficiariesDisabled: false,
   onShowPnlBreakdown: null,
+  isRefreshing: false,
 };

--- a/client/src/components/TimePill.jsx
+++ b/client/src/components/TimePill.jsx
@@ -1,14 +1,20 @@
 import PropTypes from 'prop-types';
 import { formatTimeOfDay } from '../utils/formatters';
 
-export default function TimePill({ asOf, onRefresh, className }) {
+export default function TimePill({ asOf, onRefresh, className, refreshing }) {
   const label = formatTimeOfDay(asOf);
   const pillClassName = className ? `time-pill ${className}` : 'time-pill';
   const isInteractive = typeof onRefresh === 'function';
+  const showIcon = isInteractive || refreshing;
+  const resolvedClassName = refreshing ? `${pillClassName} time-pill--refreshing` : pillClassName;
+  const refreshLabel = label ? `Refresh data (last updated ${label})` : 'Refresh data';
+  const refreshingLabel = label ? `Refreshing data (last updated ${label})` : 'Refreshing data';
 
-  const contents = (
+  const contents = refreshing ? (
+    <span className="time-pill__icon" aria-hidden="true" />
+  ) : (
     <>
-      {isInteractive && <span className="time-pill__icon" aria-hidden="true" />}
+      {showIcon && <span className="time-pill__icon" aria-hidden="true" />}
       <span className="time-pill__text">{label}</span>
     </>
   );
@@ -17,9 +23,9 @@ export default function TimePill({ asOf, onRefresh, className }) {
     return (
       <button
         type="button"
-        className={pillClassName}
+        className={resolvedClassName}
         onClick={onRefresh}
-        aria-label={`Refresh data (last updated ${label})`}
+        aria-label={refreshing ? refreshingLabel : refreshLabel}
       >
         {contents}
       </button>
@@ -27,7 +33,11 @@ export default function TimePill({ asOf, onRefresh, className }) {
   }
 
   return (
-    <div className={pillClassName} role="text" aria-label={`Last updated ${label}`}>
+    <div
+      className={resolvedClassName}
+      role="text"
+      aria-label={label ? `Last updated ${label}` : 'Last updated'}
+    >
       {contents}
     </div>
   );
@@ -37,10 +47,12 @@ TimePill.propTypes = {
   asOf: PropTypes.string,
   onRefresh: PropTypes.func,
   className: PropTypes.string,
+  refreshing: PropTypes.bool,
 };
 
 TimePill.defaultProps = {
   asOf: null,
   onRefresh: null,
   className: '',
+  refreshing: false,
 };


### PR DESCRIPTION
## Summary
- keep summary metrics and positions visible while refreshing by retaining previously loaded data
- add a refresh state to the time pill so the icon animates and the button hides the timestamp while loading
- style the refresh state so the icon centers and spins during active refreshes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dae187a98c832dab88e8614dfadda6