### PR TITLE
Add auto-refresh toggle for summary refresh pill

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -582,8 +582,7 @@ textarea {
 }
 
 .time-pill--refreshing {
-  justify-content: center;
-  gap: 0;
+  gap: 8px;
 }
 
 
@@ -596,6 +595,17 @@ textarea {
   background-position: center;
   background-size: 14px 14px;
   background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M0%200h24v24H0Z%22%20fill%3D%22none%22%2F%3E%3Cpath%20d%3D%22M17.65%206.35A8%208%200%201%200%2019.73%2014h-2.08A6%206%200%201%201%2012%206a5.92%205.92%200%200%201%204.22%201.78L13%2011h7V4Z%22%20fill%3D%22%236b7787%22%2F%3E%3C%2Fsvg%3E");
+}
+
+.time-pill--auto {
+  border-color: var(--color-accent);
+  box-shadow: inset 0 0 0 1px var(--color-accent);
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.time-pill--auto .time-pill__icon {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M0%200h24v24H0Z%22%20fill%3D%22none%22%2F%3E%3Cpath%20d%3D%22M17.65%206.35A8%208%200%201%200%2019.73%2014h-2.08A6%206%200%201%201%2012%206a5.92%205.92%200%200%201%204.22%201.78L13%2011h7V4Z%22%20fill%3D%22%2318a37a%22%2F%3E%3C%2Fsvg%3E");
 }
 
 .time-pill--refreshing .time-pill__icon {
@@ -1202,6 +1212,15 @@ button.time-pill {
 button.time-pill:hover {
   border-color: #1b2733;
   color: inherit;
+}
+
+button.time-pill.time-pill--auto:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+button.time-pill.time-pill--auto:hover .time-pill__icon {
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M0%200h24v24H0Z%22%20fill%3D%22none%22%2F%3E%3Cpath%20d%3D%22M17.65%206.35A8%208%200%201%200%2019.73%2014h-2.08A6%206%200%201%201%2012%206a5.92%205.92%200%200%201%204.22%201.78L13%2011h7V4Z%22%20fill%3D%22%2318a37a%22%2F%3E%3C%2Fsvg%3E");
 }
 .positions-table__head--numeric .positions-table__head-button {
   justify-content: flex-end;

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -72,6 +72,7 @@ export default function SummaryMetrics({
   beneficiariesDisabled,
   onShowPnlBreakdown,
   isRefreshing,
+  isAutoRefreshing,
 }) {
   const title = 'Total equity (Combined in CAD)';
   const totalEquity = balances?.totalEquity ?? null;
@@ -120,7 +121,12 @@ export default function SummaryMetrics({
               Beneficiaries
             </button>
           )}
-          <TimePill asOf={asOf} onRefresh={onRefresh} refreshing={isRefreshing} />
+          <TimePill
+            asOf={asOf}
+            onRefresh={onRefresh}
+            refreshing={isRefreshing}
+            autoRefreshing={isAutoRefreshing}
+          />
         </div>
       </header>
 
@@ -207,6 +213,7 @@ SummaryMetrics.propTypes = {
   beneficiariesDisabled: PropTypes.bool,
   onShowPnlBreakdown: PropTypes.func,
   isRefreshing: PropTypes.bool,
+  isAutoRefreshing: PropTypes.bool,
 };
 
 SummaryMetrics.defaultProps = {
@@ -220,4 +227,5 @@ SummaryMetrics.defaultProps = {
   beneficiariesDisabled: false,
   onShowPnlBreakdown: null,
   isRefreshing: false,
+  isAutoRefreshing: false,
 };

--- a/client/src/components/TimePill.jsx
+++ b/client/src/components/TimePill.jsx
@@ -1,18 +1,40 @@
 import PropTypes from 'prop-types';
 import { formatTimeOfDay } from '../utils/formatters';
 
-export default function TimePill({ asOf, onRefresh, className, refreshing }) {
+export default function TimePill({
+  asOf,
+  onRefresh,
+  className,
+  refreshing,
+  autoRefreshing,
+}) {
   const label = formatTimeOfDay(asOf);
   const pillClassName = className ? `time-pill ${className}` : 'time-pill';
   const isInteractive = typeof onRefresh === 'function';
   const showIcon = isInteractive || refreshing;
-  const resolvedClassName = refreshing ? `${pillClassName} time-pill--refreshing` : pillClassName;
+  const classNames = [pillClassName];
+  if (refreshing) {
+    classNames.push('time-pill--refreshing');
+  }
+  if (autoRefreshing) {
+    classNames.push('time-pill--auto');
+  }
+  const resolvedClassName = classNames.join(' ');
   const refreshLabel = label ? `Refresh data (last updated ${label})` : 'Refresh data';
   const refreshingLabel = label ? `Refreshing data (last updated ${label})` : 'Refreshing data';
+  const autoRefreshHint = autoRefreshing
+    ? ' Auto-refresh is on. Ctrl-click to stop auto-refresh.'
+    : ' Ctrl-click to start auto-refresh.';
+  const buttonAriaLabel = `${refreshing ? refreshingLabel : refreshLabel}.${autoRefreshHint}`;
+  const title = autoRefreshing ? 'Auto-refresh is on. Ctrl-click to stop.' : 'Ctrl-click to start auto-refresh.';
 
-  const contents = refreshing ? (
-    <span className="time-pill__icon" aria-hidden="true" />
-  ) : (
+  const handleClick = (event) => {
+    if (isInteractive) {
+      onRefresh(event);
+    }
+  };
+
+  const contents = (
     <>
       {showIcon && <span className="time-pill__icon" aria-hidden="true" />}
       <span className="time-pill__text">{label}</span>
@@ -24,8 +46,10 @@ export default function TimePill({ asOf, onRefresh, className, refreshing }) {
       <button
         type="button"
         className={resolvedClassName}
-        onClick={onRefresh}
-        aria-label={refreshing ? refreshingLabel : refreshLabel}
+        onClick={handleClick}
+        aria-label={buttonAriaLabel}
+        title={title}
+        data-auto-refreshing={autoRefreshing ? 'true' : 'false'}
       >
         {contents}
       </button>
@@ -48,6 +72,7 @@ TimePill.propTypes = {
   onRefresh: PropTypes.func,
   className: PropTypes.string,
   refreshing: PropTypes.bool,
+  autoRefreshing: PropTypes.bool,
 };
 
 TimePill.defaultProps = {
@@ -55,4 +80,5 @@ TimePill.defaultProps = {
   onRefresh: null,
   className: '',
   refreshing: false,
+  autoRefreshing: false,
 };


### PR DESCRIPTION
## Summary
- add an auto-refresh mode triggered via Ctrl-click on the summary refresh control that refreshes every 10 seconds
- keep the last-updated time visible while refreshing and style the pill when auto-refresh is active
- thread the auto-refresh state through the summary metrics so the pill reflects the current mode

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68dae428968c832d895ddbd576cae5a5