### PR TITLE
Rename beneficiaries dialog to People

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A local web app that mirrors the Questrade web portal "Summary" tab so you can r
 - Total equity card with today's and open P&L badges, cash, market value, and buying power.
 - Positions table listing symbol, description, account number, intraday/open P&L, quantities, prices, and market value.
 - Manual refresh button to force a new fetch from Questrade.
-- Beneficiaries overlay that converts every account to CAD and totals holdings for each household member.
+- People overlay that converts every account to CAD and totals holdings for each household member.
 - Automatic handling of access-token refresh and persistence of the newest refresh token.
 
 ## Notes & limitations

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,7 +4,7 @@ import SummaryMetrics from './components/SummaryMetrics';
 import PositionsTable from './components/PositionsTable';
 import { getSummary } from './api/questrade';
 import usePersistentState from './hooks/usePersistentState';
-import BeneficiariesDialog from './components/BeneficiariesDialog';
+import PeopleDialog from './components/PeopleDialog';
 import PnlHeatmapDialog from './components/PnlHeatmapDialog';
 import './App.css';
 
@@ -692,7 +692,7 @@ export default function App() {
   const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(false);
   const [positionsSort, setPositionsSort] = usePersistentState('positionsTableSort', DEFAULT_POSITIONS_SORT);
   const [positionsPnlMode, setPositionsPnlMode] = usePersistentState('positionsTablePnlMode', 'currency');
-  const [showBeneficiaries, setShowBeneficiaries] = useState(false);
+  const [showPeople, setShowPeople] = useState(false);
   const [pnlBreakdownMode, setPnlBreakdownMode] = useState(null);
   const { loading, data, error } = useSummaryData(selectedAccount, refreshKey);
 
@@ -816,7 +816,7 @@ export default function App() {
     return totals;
   }, [rawPositions, currencyRates, baseCurrency]);
 
-  const beneficiarySummary = useMemo(() => {
+  const peopleSummary = useMemo(() => {
     if (!accounts.length) {
       return { totals: [], missingAccounts: [], hasBalances: false };
     }
@@ -992,9 +992,9 @@ export default function App() {
     totalMarketValue,
   ]);
 
-  const beneficiariesTotals = beneficiarySummary.totals;
-  const beneficiariesMissingAccounts = beneficiarySummary.missingAccounts;
-  const beneficiariesDisabled = !beneficiarySummary.hasBalances;
+  const peopleTotals = peopleSummary.totals;
+  const peopleMissingAccounts = peopleSummary.missingAccounts;
+  const peopleDisabled = !peopleSummary.hasBalances;
   const showingAllAccounts = selectedAccount === 'all';
 
   const resolvedSortColumn =
@@ -1063,15 +1063,15 @@ export default function App() {
     setPnlBreakdownMode(null);
   };
 
-  const handleOpenBeneficiaries = () => {
-    if (!beneficiarySummary.hasBalances) {
+  const handleOpenPeople = () => {
+    if (!peopleSummary.hasBalances) {
       return;
     }
-    setShowBeneficiaries(true);
+    setShowPeople(true);
   };
 
-  const handleCloseBeneficiaries = () => {
-    setShowBeneficiaries(false);
+  const handleClosePeople = () => {
+    setShowPeople(false);
   };
 
   if (loading && !data) {
@@ -1115,8 +1115,8 @@ export default function App() {
             onRefresh={handleRefresh}
             displayTotalEquity={displayTotalEquity}
             usdToCadRate={usdToCadRate}
-            onShowBeneficiaries={handleOpenBeneficiaries}
-            beneficiariesDisabled={beneficiariesDisabled}
+            onShowPeople={handleOpenPeople}
+            peopleDisabled={peopleDisabled}
             onShowPnlBreakdown={orderedPositions.length ? handleShowPnlBreakdown : null}
             isRefreshing={isRefreshing}
             isAutoRefreshing={autoRefreshEnabled}
@@ -1135,13 +1135,13 @@ export default function App() {
           />
         )}
       </main>
-      {showBeneficiaries && (
-        <BeneficiariesDialog
-          totals={beneficiariesTotals}
-          onClose={handleCloseBeneficiaries}
+      {showPeople && (
+        <PeopleDialog
+          totals={peopleTotals}
+          onClose={handleClosePeople}
           baseCurrency={baseCurrency}
           isFilteredView={!showingAllAccounts}
-          missingAccounts={beneficiariesMissingAccounts}
+          missingAccounts={peopleMissingAccounts}
           asOf={asOf}
         />
       )}

--- a/client/src/components/PeopleDialog.jsx
+++ b/client/src/components/PeopleDialog.jsx
@@ -21,7 +21,7 @@ function formatAccountCount(covered, total) {
   return `${safeCovered} of ${safeTotal} ${plural}`;
 }
 
-export default function BeneficiariesDialog({
+export default function PeopleDialog({
   totals,
   onClose,
   baseCurrency,
@@ -69,7 +69,7 @@ export default function BeneficiariesDialog({
     return formatSignedPercent(percent, percentOptions);
   };
 
-  const missingBeneficiaries = useMemo(() => {
+  const missingPeople = useMemo(() => {
     if (!missingAccounts || missingAccounts.length === 0) {
       return [];
     }
@@ -82,7 +82,7 @@ export default function BeneficiariesDialog({
     return Array.from(names);
   }, [missingAccounts]);
 
-  const hasMissing = missingBeneficiaries.length > 0;
+  const hasMissing = missingPeople.length > 0;
 
   const noticeMessage = useMemo(() => {
     if (!hasMissing) {
@@ -91,11 +91,11 @@ export default function BeneficiariesDialog({
     if (isFilteredView) {
       return 'Totals reflect only the currently selected account(s). Choose “All accounts” to see the full household.';
     }
-    if (missingBeneficiaries.length) {
-      return `No balance data was returned for: ${missingBeneficiaries.join(', ')}. Try refreshing to include them.`;
+    if (missingPeople.length) {
+      return `No balance data was returned for: ${missingPeople.join(', ')}. Try refreshing to include them.`;
     }
     return 'Some accounts did not return balance data in the latest refresh. Try refreshing to include them.';
-  }, [hasMissing, isFilteredView, missingBeneficiaries]);
+  }, [hasMissing, isFilteredView, missingPeople]);
 
   return (
     <div className="beneficiaries-overlay" role="presentation" onClick={handleOverlayClick}>
@@ -103,11 +103,11 @@ export default function BeneficiariesDialog({
         className="beneficiaries-dialog"
         role="dialog"
         aria-modal="true"
-        aria-labelledby="beneficiaries-dialog-title"
+        aria-labelledby="people-dialog-title"
       >
         <header className="beneficiaries-dialog__header">
           <div className="beneficiaries-dialog__heading">
-            <h2 id="beneficiaries-dialog-title">Beneficiaries</h2>
+            <h2 id="people-dialog-title">People</h2>
             <p className="beneficiaries-dialog__subtitle">Totals in {baseCurrency}</p>
             {asOf && <p className="beneficiaries-dialog__timestamp">As of {formatDateTime(asOf)}</p>}
           </div>
@@ -180,7 +180,7 @@ export default function BeneficiariesDialog({
           </div>
         ) : (
           <div className="beneficiaries-dialog__empty">
-            No beneficiary totals are available yet. Refresh to pull the latest balances.
+            No people totals are available yet. Refresh to pull the latest balances.
           </div>
         )}
       </div>
@@ -195,7 +195,7 @@ const accountShape = PropTypes.shape({
   beneficiary: PropTypes.string,
 });
 
-BeneficiariesDialog.propTypes = {
+PeopleDialog.propTypes = {
   totals: PropTypes.arrayOf(
     PropTypes.shape({
       beneficiary: PropTypes.string.isRequired,
@@ -213,7 +213,7 @@ BeneficiariesDialog.propTypes = {
   asOf: PropTypes.string,
 };
 
-BeneficiariesDialog.defaultProps = {
+PeopleDialog.defaultProps = {
   isFilteredView: false,
   missingAccounts: [],
   asOf: null,

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -68,8 +68,8 @@ export default function SummaryMetrics({
   onRefresh,
   displayTotalEquity,
   usdToCadRate,
-  onShowBeneficiaries,
-  beneficiariesDisabled,
+  onShowPeople,
+  peopleDisabled,
   onShowPnlBreakdown,
   isRefreshing,
   isAutoRefreshing,
@@ -111,14 +111,14 @@ export default function SummaryMetrics({
           )}
         </div>
         <div className="equity-card__actions">
-          {onShowBeneficiaries && (
+          {onShowPeople && (
             <button
               type="button"
               className="equity-card__action-button"
-              onClick={onShowBeneficiaries}
-              disabled={beneficiariesDisabled}
+              onClick={onShowPeople}
+              disabled={peopleDisabled}
             >
-              Beneficiaries
+              People
             </button>
           )}
           <TimePill
@@ -209,8 +209,8 @@ SummaryMetrics.propTypes = {
   onRefresh: PropTypes.func,
   displayTotalEquity: PropTypes.number,
   usdToCadRate: PropTypes.number,
-  onShowBeneficiaries: PropTypes.func,
-  beneficiariesDisabled: PropTypes.bool,
+  onShowPeople: PropTypes.func,
+  peopleDisabled: PropTypes.bool,
   onShowPnlBreakdown: PropTypes.func,
   isRefreshing: PropTypes.bool,
   isAutoRefreshing: PropTypes.bool,
@@ -223,8 +223,8 @@ SummaryMetrics.defaultProps = {
   onRefresh: null,
   displayTotalEquity: null,
   usdToCadRate: null,
-  onShowBeneficiaries: null,
-  beneficiariesDisabled: false,
+  onShowPeople: null,
+  peopleDisabled: false,
   onShowPnlBreakdown: null,
   isRefreshing: false,
   isAutoRefreshing: false,


### PR DESCRIPTION
## Summary
- retitle the beneficiaries dialog and button copy in the UI to "People"
- rename the supporting React state/props and component to PeopleDialog
- update documentation to reference the People overlay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daea2f2928832d97cfbdb890dad0e2