### PR TITLE
Add summary action menu with clipboard export

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -308,6 +308,65 @@ textarea {
   box-shadow: none;
 }
 
+.equity-card__action-button--menu {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding-right: 12px;
+  position: relative;
+}
+
+.equity-card__action-caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid currentColor;
+  margin-left: 2px;
+}
+
+.equity-card__action-menu {
+  position: relative;
+}
+
+.equity-card__action-menu-list {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
+  list-style: none;
+  margin: 0;
+  padding: 8px 0;
+  min-width: 180px;
+  z-index: 10;
+}
+
+.equity-card__action-menu-item {
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 8px 16px;
+  font-size: 13px;
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.equity-card__action-menu-item:hover:not(:disabled),
+.equity-card__action-menu-item:focus-visible {
+  background: var(--color-surface-alt);
+  outline: none;
+}
+
+.equity-card__action-menu-item:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 .equity-card__action-button:focus-visible {
   border-color: #1b2733;
   background: var(--color-surface-alt);

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useId, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import TimePill from './TimePill';
 import {
@@ -58,6 +59,112 @@ MetricRow.defaultProps = {
   onActivate: null,
 };
 
+function ActionMenu({ onCopySummary, disabled }) {
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const containerRef = useRef(null);
+  const generatedId = useId();
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const handlePointer = (event) => {
+      if (!containerRef.current) {
+        return;
+      }
+      if (containerRef.current.contains(event.target)) {
+        return;
+      }
+      setOpen(false);
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('touchstart', handlePointer);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('touchstart', handlePointer);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
+
+  const handleToggle = () => {
+    if (disabled || busy) {
+      return;
+    }
+    setOpen((value) => !value);
+  };
+
+  const handleCopy = async () => {
+    if (!onCopySummary || disabled || busy) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await onCopySummary();
+    } catch (error) {
+      console.error('Failed to copy summary', error);
+    } finally {
+      setBusy(false);
+      setOpen(false);
+    }
+  };
+
+  const effectiveDisabled = disabled || busy;
+  const menuId = generatedId || 'equity-card-action-menu';
+
+  return (
+    <div className="equity-card__action-menu" ref={containerRef}>
+      <button
+        type="button"
+        className="equity-card__action-button equity-card__action-button--menu"
+        onClick={handleToggle}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={menuId}
+        disabled={effectiveDisabled}
+      >
+        {busy ? 'Working…' : 'Actions'}
+        <span className="equity-card__action-caret" aria-hidden="true" />
+      </button>
+      {open && (
+        <ul className="equity-card__action-menu-list" role="menu" id={menuId}>
+          <li role="none">
+            <button
+              type="button"
+              className="equity-card__action-menu-item"
+              role="menuitem"
+              onClick={handleCopy}
+              disabled={busy}
+            >
+              Copy to clipboard
+            </button>
+          </li>
+        </ul>
+      )}
+    </div>
+  );
+}
+
+ActionMenu.propTypes = {
+  onCopySummary: PropTypes.func,
+  disabled: PropTypes.bool,
+};
+
+ActionMenu.defaultProps = {
+  onCopySummary: null,
+  disabled: false,
+};
+
 export default function SummaryMetrics({
   currencyOption,
   currencyOptions,
@@ -73,6 +180,7 @@ export default function SummaryMetrics({
   onShowPnlBreakdown,
   isRefreshing,
   isAutoRefreshing,
+  onCopySummary,
 }) {
   const title = 'Total equity (Combined in CAD)';
   const totalEquity = balances?.totalEquity ?? null;
@@ -121,6 +229,7 @@ export default function SummaryMetrics({
               Beneficiaries
             </button>
           )}
+          {onCopySummary && <ActionMenu onCopySummary={onCopySummary} />}
           <TimePill
             asOf={asOf}
             onRefresh={onRefresh}
@@ -214,6 +323,7 @@ SummaryMetrics.propTypes = {
   onShowPnlBreakdown: PropTypes.func,
   isRefreshing: PropTypes.bool,
   isAutoRefreshing: PropTypes.bool,
+  onCopySummary: PropTypes.func,
 };
 
 SummaryMetrics.defaultProps = {
@@ -228,4 +338,5 @@ SummaryMetrics.defaultProps = {
   onShowPnlBreakdown: null,
   isRefreshing: false,
   isAutoRefreshing: false,
+  onCopySummary: null,
 };


### PR DESCRIPTION
## Summary
- add an actions menu to the equity summary header with a clipboard option
- implement account summary text generation including positions table
- style the new action menu button and dropdown

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daebf66758832da7f42d212a7e99ef