### PR TITLE
Make USD to CAD label link to Google search

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -616,6 +616,20 @@ textarea {
   gap: 6px;
 }
 
+.equity-card__subtext-link {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.equity-card__subtext-link:focus,
+.equity-card__subtext-link:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
 .equity-card__subtext-label {
   font-weight: 600;
   letter-spacing: 0.02em;

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -211,7 +211,14 @@ export default function SummaryMetrics({
           <p className="equity-card__value">{formatMoney(displayTotalEquity ?? totalEquity)}</p>
           {usdToCadRate !== null && (
             <p className="equity-card__subtext">
-              <span className="equity-card__subtext-label">USD → CAD</span>
+              <a
+                className="equity-card__subtext-label"
+                href="https://www.google.ca/search?sourceid=chrome-psyapi2&ion=1&espv=2&ie=UTF-8&q=usd%20=%20?%20cad"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                USD → CAD
+              </a>
               <span className="equity-card__subtext-value">
                 {formatNumber(usdToCadRate, { minimumFractionDigits: 3, maximumFractionDigits: 3 })}
               </span>

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -212,16 +212,16 @@ export default function SummaryMetrics({
           {usdToCadRate !== null && (
             <p className="equity-card__subtext">
               <a
-                className="equity-card__subtext-label"
+                className="equity-card__subtext-link"
                 href="https://www.google.ca/search?sourceid=chrome-psyapi2&ion=1&espv=2&ie=UTF-8&q=usd%20=%20?%20cad"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                USD → CAD
+                <span className="equity-card__subtext-label">USD → CAD</span>
+                <span className="equity-card__subtext-value">
+                  {formatNumber(usdToCadRate, { minimumFractionDigits: 3, maximumFractionDigits: 3 })}
+                </span>
               </a>
-              <span className="equity-card__subtext-value">
-                {formatNumber(usdToCadRate, { minimumFractionDigits: 3, maximumFractionDigits: 3 })}
-              </span>
             </p>
           )}
         </div>


### PR DESCRIPTION
## Summary
- wrap the USD → CAD label in the equity card with an anchor tag
- open the Google currency search in a new tab with appropriate security attributes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf5681028832d800a7aa9ebb030af