### PR TITLE
Align actions dropdown menu with button left edge

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -333,7 +333,7 @@ textarea {
 .equity-card__action-menu-list {
   position: absolute;
   top: calc(100% + 6px);
-  right: 0;
+  left: 0;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-card);


### PR DESCRIPTION
## Summary
- align the actions dropdown menu with the left edge of its trigger button for consistent positioning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf73c8670832d87ce6b37ce84c889