### PR TITLE
Add chat links to account actions menu

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -346,6 +346,7 @@ textarea {
 }
 
 .equity-card__action-menu-item {
+  display: block;
   width: 100%;
   background: none;
   border: none;
@@ -354,6 +355,7 @@ textarea {
   font-size: 13px;
   color: var(--color-text-primary);
   cursor: pointer;
+  text-decoration: none;
 }
 
 .equity-card__action-menu-item:hover:not(:disabled),

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -923,6 +923,21 @@ export default function App() {
   const { loading, data, error } = useSummaryData(selectedAccount, refreshKey);
 
   const accounts = useMemo(() => data?.accounts ?? [], [data?.accounts]);
+  const selectedAccountInfo = useMemo(() => {
+    if (!selectedAccount || selectedAccount === 'all') {
+      return null;
+    }
+    return (
+      accounts.find((account) => {
+        if (!account) {
+          return false;
+        }
+        const accountId = typeof account.id === 'string' ? account.id : null;
+        const accountNumber = typeof account.number === 'string' ? account.number : null;
+        return accountId === selectedAccount || accountNumber === selectedAccount;
+      }) || null
+    );
+  }, [accounts, selectedAccount]);
   const rawPositions = useMemo(() => data?.positions ?? [], [data?.positions]);
   const balances = data?.balances || null;
   const accountBalances = data?.accountBalances ?? EMPTY_OBJECT;
@@ -1222,6 +1237,13 @@ export default function App() {
   const peopleMissingAccounts = peopleSummary.missingAccounts;
   const peopleDisabled = !peopleSummary.hasBalances;
   const showingAllAccounts = selectedAccount === 'all';
+  const selectedAccountChatUrl = useMemo(() => {
+    if (!selectedAccountInfo || typeof selectedAccountInfo.chatURL !== 'string') {
+      return null;
+    }
+    const trimmed = selectedAccountInfo.chatURL.trim();
+    return trimmed || null;
+  }, [selectedAccountInfo]);
 
   const resolvedSortColumn =
     positionsSort && typeof positionsSort.column === 'string' && positionsSort.column.trim()
@@ -1398,6 +1420,7 @@ export default function App() {
             isRefreshing={isRefreshing}
             isAutoRefreshing={autoRefreshEnabled}
             onCopySummary={handleCopySummary}
+            chatUrl={selectedAccountChatUrl}
           />
         )}
 

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -59,11 +59,14 @@ MetricRow.defaultProps = {
   onActivate: null,
 };
 
-function ActionMenu({ onCopySummary, disabled }) {
+function ActionMenu({ onCopySummary, disabled, chatUrl }) {
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const containerRef = useRef(null);
   const generatedId = useId();
+  const normalizedChatUrl = typeof chatUrl === 'string' ? chatUrl.trim() : '';
+  const hasChatLink = Boolean(normalizedChatUrl);
+  const hasCopyAction = typeof onCopySummary === 'function';
 
   useEffect(() => {
     if (!open) {
@@ -138,17 +141,33 @@ function ActionMenu({ onCopySummary, disabled }) {
       </button>
       {open && (
         <ul className="equity-card__action-menu-list" role="menu" id={menuId}>
-          <li role="none">
-            <button
-              type="button"
-              className="equity-card__action-menu-item"
-              role="menuitem"
-              onClick={handleCopy}
-              disabled={busy}
-            >
-              Copy to clipboard
-            </button>
-          </li>
+          {hasChatLink && (
+            <li role="none">
+              <a
+                className="equity-card__action-menu-item"
+                role="menuitem"
+                href={normalizedChatUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setOpen(false)}
+              >
+                Chat
+              </a>
+            </li>
+          )}
+          {hasCopyAction && (
+            <li role="none">
+              <button
+                type="button"
+                className="equity-card__action-menu-item"
+                role="menuitem"
+                onClick={handleCopy}
+                disabled={busy}
+              >
+                Copy to clipboard
+              </button>
+            </li>
+          )}
         </ul>
       )}
     </div>
@@ -158,11 +177,13 @@ function ActionMenu({ onCopySummary, disabled }) {
 ActionMenu.propTypes = {
   onCopySummary: PropTypes.func,
   disabled: PropTypes.bool,
+  chatUrl: PropTypes.string,
 };
 
 ActionMenu.defaultProps = {
   onCopySummary: null,
   disabled: false,
+  chatUrl: null,
 };
 
 export default function SummaryMetrics({
@@ -181,6 +202,7 @@ export default function SummaryMetrics({
   isRefreshing,
   isAutoRefreshing,
   onCopySummary,
+  chatUrl,
 }) {
   const title = 'Total equity (Combined in CAD)';
   const totalEquity = balances?.totalEquity ?? null;
@@ -229,7 +251,7 @@ export default function SummaryMetrics({
               People
             </button>
           )}
-          {onCopySummary && <ActionMenu onCopySummary={onCopySummary} />}
+          {(onCopySummary || chatUrl) && <ActionMenu onCopySummary={onCopySummary} chatUrl={chatUrl} />}
           <TimePill
             asOf={asOf}
             onRefresh={onRefresh}
@@ -324,6 +346,7 @@ SummaryMetrics.propTypes = {
   isRefreshing: PropTypes.bool,
   isAutoRefreshing: PropTypes.bool,
   onCopySummary: PropTypes.func,
+  chatUrl: PropTypes.string,
 };
 
 SummaryMetrics.defaultProps = {
@@ -339,4 +362,5 @@ SummaryMetrics.defaultProps = {
   isRefreshing: false,
   isAutoRefreshing: false,
   onCopySummary: null,
+  chatUrl: null,
 };

--- a/server/accounts.example.json
+++ b/server/accounts.example.json
@@ -1,7 +1,8 @@
 {
   "53384039": {
     "name": "TFSA - Primary",
-    "uuid": "ac4ea32e-3034-4232-056a-194d8395463c"
+    "uuid": "ac4ea32e-3034-4232-056a-194d8395463c",
+    "chatURL": "https://chat.openai.com/share/example"
   },
   "53384040": {
     "name": "Margin",

--- a/server/src/accountNames.js
+++ b/server/src/accountNames.js
@@ -339,7 +339,12 @@ function loadAccountOverrides() {
   const stats = fs.statSync(filePath);
   const marker = createMarker(stats);
   if (marker && marker === cachedMarker) {
-    return { overrides: cachedOverrides, portalOverrides: cachedPortalOverrides, ordering: cachedOrdering };
+    return {
+      overrides: cachedOverrides,
+      portalOverrides: cachedPortalOverrides,
+      chatOverrides: cachedChatOverrides,
+      ordering: cachedOrdering,
+    };
   }
   const content = fs.readFileSync(filePath, 'utf-8').replace(/^\uFEFF/, '');
   if (!content.trim()) {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -8,6 +8,7 @@ require('dotenv').config();
 const {
   getAccountNameOverrides,
   getAccountPortalOverrides,
+  getAccountChatOverrides,
   getAccountOrdering,
 } = require('./accountNames');
 const { getAccountBeneficiaries } = require('./accountBeneficiaries');
@@ -286,6 +287,10 @@ function resolveAccountDisplayName(overrides, account, login) {
 }
 
 function resolveAccountPortalId(overrides, account, login) {
+  return resolveAccountOverrideValue(overrides, account, login);
+}
+
+function resolveAccountChatUrl(overrides, account, login) {
   return resolveAccountOverrideValue(overrides, account, login);
 }
 
@@ -718,6 +723,7 @@ app.get('/api/summary', async function (req, res) {
     const accountCollections = [];
     const accountNameOverrides = getAccountNameOverrides();
     const accountPortalOverrides = getAccountPortalOverrides();
+    const accountChatOverrides = getAccountChatOverrides();
     const configuredOrdering = getAccountOrdering();
     const accountBeneficiaries = getAccountBeneficiaries();
     for (const login of allLogins) {
@@ -745,6 +751,12 @@ app.get('/api/summary', async function (req, res) {
         const overridePortalId = resolveAccountPortalId(accountPortalOverrides, normalizedAccount, login);
         if (overridePortalId) {
           normalizedAccount.portalAccountId = overridePortalId;
+        }
+        const overrideChatUrl = resolveAccountChatUrl(accountChatOverrides, normalizedAccount, login);
+        if (overrideChatUrl) {
+          normalizedAccount.chatURL = overrideChatUrl;
+        } else if (normalizedAccount.chatURL === undefined) {
+          normalizedAccount.chatURL = null;
         }
         const defaultBeneficiary = accountBeneficiaries.defaultBeneficiary || null;
         if (defaultBeneficiary) {
@@ -917,6 +929,7 @@ app.get('/api/summary', async function (req, res) {
         loginId: account.loginId,
         beneficiary: account.beneficiary || null,
         portalAccountId: account.portalAccountId || null,
+        chatURL: account.chatURL || null,
       };
     });
 


### PR DESCRIPTION
## Summary
- add support for `chatURL` overrides on the server and include the link in account responses
- show a Chat entry ahead of Copy to clipboard in the summary action menu when the selected account provides a chat URL
- document the new configuration option in the example accounts file

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68daf7a6fe0c832da825fb0a99c1a5dd