### PR TITLE
Support default account selection from accounts config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A local web app that mirrors the Questrade web portal "Summary" tab so you can r
      inside the `server` directory. Repeat for every login you want to mirror (for example, `--id=daniel` and `--id=meredith`). When omitted, `--id` defaults to `primary` and updates that entry.
    - Optionally adjust `CLIENT_ORIGIN` or `PORT` if you change the frontend host.
    - (Optional) Copy `server/account-beneficiaries.example.json` to `server/account-beneficiaries.json` and replace the placeholder account numbers with your own. The proxy reads this file to attach household beneficiary metadata (for example "Eli Bigham" or "Philanthropy") to each account.
-   - (Optional) Copy `server/accounts.example.json` to `server/accounts.json` to define friendly account names and Questrade portal UUIDs per account number. The proxy watches this file for updates and forwards the resolved `portalAccountId` to the UI so Ctrl/⌘-clicking the account selector can open the matching page in the Questrade portal.
+   - (Optional) Copy `server/accounts.example.json` to `server/accounts.json` to define friendly account names and Questrade portal UUIDs per account number. The proxy watches this file for updates and forwards the resolved `portalAccountId` to the UI so Ctrl/⌘-clicking the account selector can open the matching page in the Questrade portal. You can also mark an entry with `"default": true` to have the UI automatically switch to that account after a restart.
    - Copy `client/.env.example` to `client/.env` if you want to point the UI at a non-default proxy URL.
 
 2. Install dependencies

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -922,7 +922,44 @@ export default function App() {
   const [pnlBreakdownMode, setPnlBreakdownMode] = useState(null);
   const { loading, data, error } = useSummaryData(selectedAccount, refreshKey);
 
+  const userSelectedAccountRef = useRef(false);
+
   const accounts = useMemo(() => data?.accounts ?? [], [data?.accounts]);
+  const defaultAccountId = data?.defaultAccountId ?? null;
+
+  useEffect(() => {
+    if (!defaultAccountId) {
+      return;
+    }
+    if (userSelectedAccountRef.current) {
+      return;
+    }
+    if (selectedAccount && selectedAccount !== 'all') {
+      return;
+    }
+    const normalizedDefault = String(defaultAccountId).trim();
+    if (!normalizedDefault) {
+      return;
+    }
+    const hasMatchingAccount = accounts.some((account) => {
+      if (!account) {
+        return false;
+      }
+      const accountNumber = account.number == null ? null : String(account.number).trim();
+      const accountId = account.id == null ? null : String(account.id).trim();
+      return normalizedDefault === accountNumber || normalizedDefault === accountId;
+    });
+    if (!hasMatchingAccount) {
+      return;
+    }
+    setSelectedAccount(normalizedDefault);
+  }, [defaultAccountId, accounts, selectedAccount, setSelectedAccount]);
+
+  const handleAccountChange = useCallback((nextAccount) => {
+    userSelectedAccountRef.current = true;
+    setSelectedAccount(nextAccount);
+  }, [setSelectedAccount]);
+
   const selectedAccountInfo = useMemo(() => {
     if (!selectedAccount || selectedAccount === 'all') {
       return null;
@@ -1391,7 +1428,7 @@ export default function App() {
           <AccountSelector
             accounts={accounts}
             selected={selectedAccount}
-            onChange={setSelectedAccount}
+            onChange={handleAccountChange}
             disabled={loading && !data}
           />
         </header>

--- a/client/src/api/questrade.js
+++ b/client/src/api/questrade.js
@@ -1,16 +1,19 @@
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000';
 
-function buildUrl(accountId) {
+function buildUrl(accountId, options = {}) {
   const base = API_BASE_URL.replace(/\/$/, '');
   const url = new URL('/api/summary', base);
   if (accountId && accountId !== 'all') {
     url.searchParams.set('accountId', accountId);
   }
+  if (options && options.preferDefaultAccount) {
+    url.searchParams.set('preferDefaultAccount', '1');
+  }
   return url.toString();
 }
 
-export async function getSummary(accountId) {
-  const response = await fetch(buildUrl(accountId));
+export async function getSummary(accountId, options) {
+  const response = await fetch(buildUrl(accountId, options));
   if (!response.ok) {
     const text = await response.text();
     throw new Error(text || 'Failed to load summary data');

--- a/server/accounts.example.json
+++ b/server/accounts.example.json
@@ -1,6 +1,7 @@
 {
   "53384039": {
     "name": "TFSA - Primary",
+    "default": true,
     "uuid": "ac4ea32e-3034-4232-056a-194d8395463c",
     "chatURL": "https://chat.openai.com/share/example"
   },


### PR DESCRIPTION
## Summary
- add support for recording a default account in accounts.json and expose it from the server API
- teach the client to automatically switch to the configured default account on startup unless the user has chosen one
- document the new configuration option and update the sample accounts file to illustrate its usage

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db0e8e52d0832d8bccd7acf6239bde