### PR TITLE
Ignore qqq cache while running nodemon

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "nodemon --ignore token-store.json src/index.js",
+    "dev": "nodemon --ignore token-store.json --ignore data/qqq-cache/** src/index.js",
     "seed-token": "node scripts/seed-refresh.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- update the dev nodemon command to ignore changes under data/qqq-cache

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68db10f306a4832db3c213bc97e88726