### PR TITLE
Support configurable default account

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A local web app that mirrors the Questrade web portal "Summary" tab so you can r
      inside the `server` directory. Repeat for every login you want to mirror (for example, `--id=daniel` and `--id=meredith`). When omitted, `--id` defaults to `primary` and updates that entry.
    - Optionally adjust `CLIENT_ORIGIN` or `PORT` if you change the frontend host.
    - (Optional) Copy `server/account-beneficiaries.example.json` to `server/account-beneficiaries.json` and replace the placeholder account numbers with your own. The proxy reads this file to attach household beneficiary metadata (for example "Eli Bigham" or "Philanthropy") to each account.
-   - (Optional) Copy `server/accounts.example.json` to `server/accounts.json` to define friendly account names and Questrade portal UUIDs per account number. The proxy watches this file for updates and forwards the resolved `portalAccountId` to the UI so Ctrl/⌘-clicking the account selector can open the matching page in the Questrade portal.
+   - (Optional) Copy `server/accounts.example.json` to `server/accounts.json` to define friendly account names and Questrade portal UUIDs per account number. The proxy watches this file for updates and forwards the resolved `portalAccountId` to the UI so Ctrl/⌘-clicking the account selector can open the matching page in the Questrade portal. You can also mark an account object with `"default": true` to have the dashboard start on that account instead of the combined "All accounts" view after a restart.
    - Copy `client/.env.example` to `client/.env` if you want to point the UI at a non-default proxy URL.
 
 2. Install dependencies

--- a/server/accounts.example.json
+++ b/server/accounts.example.json
@@ -3,7 +3,8 @@
     "name": "TFSA - Primary",
     "uuid": "ac4ea32e-3034-4232-056a-194d8395463c",
     "chatURL": "https://chat.openai.com/share/example",
-    "showQQQDetails": true
+    "showQQQDetails": true,
+    "default": true
   },
   "53384040": {
     "name": "Margin",


### PR DESCRIPTION
## Summary
- allow marking an account entry with `"default": true` in accounts.json and expose that metadata through the summary API
- ensure the frontend requests the configured default account on first load and keeps the selector in sync without loading the aggregated view first
- document the new option and show it in the example accounts file

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68db1b0a0df8832db76bfc7307605ebd