### PR TITLE
Reduce QQQ chart padding and adjust focus styling

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1383,8 +1383,8 @@ button.time-pill:hover .time-pill__icon {
 }
 
 .qqq-section__control-select:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+  outline: none;
+  border-color: var(--color-border-active);
 }
 
 .qqq-section__control-select:disabled {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1473,7 +1473,7 @@ button.time-pill:hover .time-pill__icon {
 .qqq-section__series-path {
   fill: none;
   stroke: var(--color-accent);
-  stroke-width: 2.5;
+  stroke-width: 1.25;
   stroke-linejoin: round;
   stroke-linecap: round;
 }

--- a/client/src/components/QqqTemperatureSection.jsx
+++ b/client/src/components/QqqTemperatureSection.jsx
@@ -4,7 +4,7 @@ import { formatDate, formatNumber, formatPercent } from '../utils/formatters';
 
 const CHART_WIDTH = 720;
 const CHART_HEIGHT = 260;
-const PADDING = { top: 24, right: 0, bottom: 13, left: 0 };
+const PADDING = { top: 12, right: 0, bottom: 9, left: 0 };
 
 const TIMEFRAME_OPTIONS = [
   { value: '1M', label: '1 month' },

--- a/client/src/components/QqqTemperatureSection.jsx
+++ b/client/src/components/QqqTemperatureSection.jsx
@@ -4,7 +4,7 @@ import { formatDate, formatNumber, formatPercent } from '../utils/formatters';
 
 const CHART_WIDTH = 720;
 const CHART_HEIGHT = 260;
-const PADDING = { top: 12, right: 0, bottom: 9, left: 0 };
+const PADDING = { top: 6, right: 0, bottom: 4.5, left: 0 };
 
 const TIMEFRAME_OPTIONS = [
   { value: '1M', label: '1 month' },

--- a/client/src/components/QqqTemperatureSection.jsx
+++ b/client/src/components/QqqTemperatureSection.jsx
@@ -4,7 +4,7 @@ import { formatDate, formatNumber, formatPercent } from '../utils/formatters';
 
 const CHART_WIDTH = 720;
 const CHART_HEIGHT = 260;
-const PADDING = { top: 24, right: 0, bottom: 36, left: 0 };
+const PADDING = { top: 24, right: 0, bottom: 13, left: 0 };
 
 const TIMEFRAME_OPTIONS = [
   { value: '1M', label: '1 month' },


### PR DESCRIPTION
## Summary
- decrease the QQQ temperature chart bottom padding to reduce extra whitespace below the data
- remove the green outline from the QQQ timeframe dropdown focus state while retaining a subtle border color change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db208900d8832d8c693b63093bd3b4