### PR TITLE
Adjust QQQ temperature label formatting

### DIFF
--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -203,6 +203,8 @@ export default function SummaryMetrics({
   isAutoRefreshing,
   onCopySummary,
   chatUrl,
+  showQqqTemperature,
+  qqqSummary,
 }) {
   const title = 'Total equity (Combined in CAD)';
   const totalEquity = balances?.totalEquity ?? null;
@@ -244,6 +246,26 @@ export default function SummaryMetrics({
                   {formatNumber(usdToCadRate, { minimumFractionDigits: 3, maximumFractionDigits: 3 })}
                 </span>
               </a>
+            </p>
+          )}
+          {showQqqTemperature && (
+            <p className="equity-card__subtext" role="status">
+              <span className="equity-card__subtext-value">
+                {(() => {
+                  const status = qqqSummary?.status || 'loading';
+                  if (status === 'ready' && Number.isFinite(qqqSummary?.temperature)) {
+                    const formattedTemp = formatNumber(qqqSummary.temperature, {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    });
+                    return `QQQ temperature: ${formattedTemp}`;
+                  }
+                  if (status === 'error') {
+                    return qqqSummary?.message || 'Unable to load';
+                  }
+                  return 'QQQ temperature: Loading…';
+                })()}
+              </span>
             </p>
           )}
         </div>
@@ -354,6 +376,13 @@ SummaryMetrics.propTypes = {
   isAutoRefreshing: PropTypes.bool,
   onCopySummary: PropTypes.func,
   chatUrl: PropTypes.string,
+  showQqqTemperature: PropTypes.bool,
+  qqqSummary: PropTypes.shape({
+    status: PropTypes.oneOf(['loading', 'ready', 'error']),
+    temperature: PropTypes.number,
+    date: PropTypes.string,
+    message: PropTypes.string,
+  }),
 };
 
 SummaryMetrics.defaultProps = {
@@ -370,4 +399,6 @@ SummaryMetrics.defaultProps = {
   isAutoRefreshing: false,
   onCopySummary: null,
   chatUrl: null,
+  showQqqTemperature: false,
+  qqqSummary: null,
 };


### PR DESCRIPTION
## Summary
- fetch QQQ temperature data when the combined "All accounts" view is active and reuse it across refreshes
- surface the latest QQQ temperature (with loading and error messaging) alongside the summary card metrics
- present the QQQ temperature reading inline without the bold label, leading "T", or date stamp

## Testing
- npm --prefix client run lint

------
https://chatgpt.com/codex/tasks/task_e_68db2736d3b0832db002994e1d563db2