### PR TITLE
Add open P&L percent to summary metrics

### DIFF
--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -226,6 +226,11 @@ export default function SummaryMetrics({
     dayPercentValue !== null && Number.isFinite(dayPercentValue)
       ? formatSignedPercent(dayPercentValue, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
       : null;
+  const openPercentValue = safeTotalEquity ? ((pnl?.openPnl || 0) / safeTotalEquity) * 100 : null;
+  const openPercent =
+    openPercentValue !== null && Number.isFinite(openPercentValue)
+      ? formatSignedPercent(openPercentValue, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+      : null;
 
   return (
     <section className="equity-card">
@@ -323,6 +328,7 @@ export default function SummaryMetrics({
           <MetricRow
             label="Open P&L"
             value={formattedOpen}
+            extra={openPercent ? `(${openPercent})` : null}
             tone={openTone}
             onActivate={onShowPnlBreakdown ? () => onShowPnlBreakdown('open') : null}
           />

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -220,17 +220,39 @@ export default function SummaryMetrics({
   const formattedOpen = formatSignedMoney(pnl?.openPnl ?? null);
   const formattedTotal = formatSignedMoney(pnl?.totalPnl ?? null);
 
-  const safeTotalEquity = typeof totalEquity === 'number' && totalEquity !== 0 ? totalEquity : null;
-  const dayPercentValue = safeTotalEquity ? ((pnl?.dayPnl || 0) / safeTotalEquity) * 100 : null;
-  const dayPercent =
-    dayPercentValue !== null && Number.isFinite(dayPercentValue)
-      ? formatSignedPercent(dayPercentValue, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-      : null;
-  const openPercentValue = safeTotalEquity ? ((pnl?.openPnl || 0) / safeTotalEquity) * 100 : null;
-  const openPercent =
-    openPercentValue !== null && Number.isFinite(openPercentValue)
-      ? formatSignedPercent(openPercentValue, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-      : null;
+  const safeTotalEquity = Number.isFinite(totalEquity) ? totalEquity : null;
+
+  const formatPnlPercent = (change) => {
+    if (!Number.isFinite(change)) {
+      if (change === 0) {
+        return formatSignedPercent(0, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+      }
+      return null;
+    }
+
+    if (change === 0) {
+      return formatSignedPercent(0, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    }
+
+    if (safeTotalEquity === null) {
+      return null;
+    }
+
+    const baseValue = safeTotalEquity - change;
+    if (!Number.isFinite(baseValue) || baseValue === 0) {
+      return null;
+    }
+
+    const percentValue = (change / baseValue) * 100;
+    if (!Number.isFinite(percentValue)) {
+      return null;
+    }
+
+    return formatSignedPercent(percentValue, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  };
+
+  const dayPercent = formatPnlPercent(pnl?.dayPnl);
+  const openPercent = formatPnlPercent(pnl?.openPnl);
 
   return (
     <section className="equity-card">


### PR DESCRIPTION
## Summary
- calculate the open P&L percentage based on total equity and format it for display
- show the formatted percentage next to the open P&L metric to match the day P&L styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db4b9a60b8832d83ddaeef16f1e5ee