### PR TITLE
Fix QQQ temperature label flicker during refresh

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1333,15 +1333,6 @@ export default function App() {
     fetchQqqTemperature,
   ]);
   const qqqSummary = useMemo(() => {
-    if (qqqLoading) {
-      return { status: 'loading' };
-    }
-    if (qqqError) {
-      return {
-        status: 'error',
-        message: qqqError.message || 'Unable to load QQQ temperature data',
-      };
-    }
     const latestTemperature = Number(qqqData?.latest?.temperature);
     const latestDate =
       typeof qqqData?.latest?.date === 'string' && qqqData.latest.date.trim()
@@ -1349,16 +1340,30 @@ export default function App() {
         : typeof qqqData?.rangeEnd === 'string'
         ? qqqData.rangeEnd
         : null;
+
     if (Number.isFinite(latestTemperature)) {
       return {
-        status: 'ready',
+        status: qqqLoading ? 'refreshing' : 'ready',
         temperature: latestTemperature,
         date: latestDate,
       };
     }
+
+    if (qqqError) {
+      return {
+        status: 'error',
+        message: qqqError.message || 'Unable to load QQQ temperature data',
+      };
+    }
+
+    if (qqqLoading) {
+      return { status: 'loading' };
+    }
+
     if (qqqData) {
       return { status: 'error', message: 'QQQ temperature unavailable' };
     }
+
     return { status: 'loading' };
   }, [qqqData, qqqLoading, qqqError]);
 

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -282,7 +282,8 @@ export default function SummaryMetrics({
               <span className="equity-card__subtext-value">
                 {(() => {
                   const status = qqqSummary?.status || 'loading';
-                  if (status === 'ready' && Number.isFinite(qqqSummary?.temperature)) {
+                  const hasTemperature = Number.isFinite(qqqSummary?.temperature);
+                  if ((status === 'ready' || status === 'refreshing') && hasTemperature) {
                     const formattedTemp = formatNumber(qqqSummary.temperature, {
                       minimumFractionDigits: 2,
                       maximumFractionDigits: 2,


### PR DESCRIPTION
## Summary
- keep the previously loaded QQQ temperature data visible while a refresh request is in flight
- treat the new refreshing state as ready in the summary banner so the label no longer swaps to the loading message

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbdc29e974832daf7ce38ca095c077