### PR TITLE
Add unit tests for performance utilities

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,7 +21,8 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.4.0",
-        "vite": "^7.1.7"
+        "vite": "^7.1.7",
+        "vitest": "^2.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1322,6 +1323,92 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1379,6 +1466,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1438,6 +1535,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1467,6 +1574,23 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1481,6 +1605,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -1550,6 +1684,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1561,6 +1705,13 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.224.tgz",
       "integrity": "sha512-kWAoUu/bwzvnhpdZSIc6KUyvkI1rbRXMT0Eq8pKReyOyaPZcctMli+EgvcN1PAvwVc7Tdo4Fxi2PsLNDU05mdg==",
       "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.10",
@@ -1783,6 +1934,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1790,6 +1951,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2104,6 +2275,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2111,6 +2289,16 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/minimatch": {
@@ -2244,6 +2432,23 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -2438,6 +2643,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2446,6 +2658,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -2471,6 +2697,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2485,6 +2725,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/type-check": {
@@ -2612,6 +2882,1102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2625,6 +3991,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "prop-types": "^15.8.1",
@@ -23,6 +24,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.4.0",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^2.1.8"
   }
 }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -588,6 +588,275 @@ textarea {
   color: var(--color-text-secondary);
 }
 
+.performance-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1200;
+}
+
+.performance-dialog {
+  background: var(--color-surface);
+  border-radius: 20px;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+  width: min(840px, 100%);
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+}
+
+.performance-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 24px 28px 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.performance-dialog__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.performance-dialog__heading h2 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.performance-dialog__subtitle {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-text-secondary);
+}
+
+.performance-dialog__close {
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.performance-dialog__close:hover,
+.performance-dialog__close:focus-visible {
+  color: var(--color-text-primary);
+  outline: none;
+}
+
+.performance-dialog__body {
+  padding: 24px 28px 32px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.performance-dialog__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 15px;
+  color: var(--color-text-secondary);
+  background: var(--color-surface-alt);
+  border-radius: 14px;
+  padding: 12px 16px;
+}
+
+.performance-dialog__status--error {
+  color: var(--color-negative);
+  background: rgba(255, 101, 101, 0.12);
+}
+
+.performance-dialog__status--empty {
+  color: var(--color-text-muted);
+  background: var(--color-surface-alt);
+}
+
+.performance-dialog__retry {
+  margin-top: 12px;
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  padding: 6px 14px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  font-size: 13px;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.performance-dialog__retry:hover,
+.performance-dialog__retry:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  outline: none;
+}
+
+.performance-dialog__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+}
+
+.performance-dialog__metric {
+  min-width: 220px;
+}
+
+.performance-dialog__metric dt {
+  margin: 0 0 6px;
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.performance-dialog__metric dd {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.performance-dialog__metric-value {
+  font-size: 26px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.performance-dialog__metric-value--positive {
+  color: var(--color-accent);
+}
+
+.performance-dialog__metric-value--negative {
+  color: var(--color-negative);
+}
+
+.performance-dialog__metric-value--neutral {
+  color: var(--color-text-primary);
+}
+
+.performance-dialog__metric-extra {
+  font-size: 16px;
+  color: var(--color-text-muted);
+}
+
+.performance-dialog__metric--cagr dd {
+  gap: 14px;
+}
+
+.performance-dialog__period-select select {
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-pill);
+  padding: 6px 12px;
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.performance-dialog__period-select select:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.performance-dialog__details {
+  margin: 0;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.performance-dialog__details-row dt {
+  margin: 0 0 4px;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.performance-dialog__details-row dd {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.performance-dialog__chart {
+  width: 100%;
+}
+
+.performance-dialog__chart--empty {
+  border: 1px dashed var(--color-border);
+  border-radius: 16px;
+  padding: 32px;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.performance-dialog__chart-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.performance-dialog__chart-surface {
+  fill: var(--color-surface-alt);
+  stroke: var(--color-border);
+  stroke-width: 1;
+}
+
+.performance-dialog__chart-line {
+  fill: none;
+  stroke: var(--color-accent);
+  stroke-width: 2;
+}
+
+.performance-dialog__chart-marker {
+  fill: var(--color-accent-soft);
+  stroke: var(--color-accent);
+  stroke-width: 1.5;
+}
+
+.performance-dialog__chart-marker--latest {
+  fill: var(--color-accent);
+}
+
+.performance-dialog__chart-guide {
+  stroke: var(--color-border);
+  stroke-dasharray: 4 4;
+}
+
+.performance-dialog__chart-footer {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.performance-dialog__warnings {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.performance-dialog__warnings ul {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 4px;
+}
+
 .equity-card__heading {
   display: flex;
   flex-direction: column;
@@ -795,6 +1064,48 @@ textarea {
 
 .equity-card__metric-value--neutral {
   color: var(--color-text-primary);
+}
+
+.equity-card__metric-node {
+  display: inline-flex;
+  align-items: center;
+}
+
+.equity-card__metric-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
+}
+
+.equity-card__metric-button:hover:not(:disabled),
+.equity-card__metric-button:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  outline: none;
+}
+
+.equity-card__metric-button:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.equity-card__metric-button-icon {
+  width: 14px;
+  height: 14px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 14px 14px;
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M0%200h24v24H0Z%22%20fill%3D%22none%22%2F%3E%3Cpath%20d%3D%22M17.65%206.35A8%208%200%201%200%2019.73%2014h-2.08A6%206%200%201%201%2012%206a5.92%205.92%200%200%201%204.22%201.78L13%2011h7V4Z%22%20fill%3D%22%236b7787%22%2F%3E%3C%2Fsvg%3E");
+  animation: time-pill-spin 1s linear infinite;
 }
 
 .equity-card__metric-extra {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,11 +2,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import AccountSelector from './components/AccountSelector';
 import SummaryMetrics from './components/SummaryMetrics';
 import PositionsTable from './components/PositionsTable';
-import { getSummary, getQqqTemperature } from './api/questrade';
+import { getSummary, getQqqTemperature, getAccountPerformance } from './api/questrade';
 import usePersistentState from './hooks/usePersistentState';
 import PeopleDialog from './components/PeopleDialog';
 import PnlHeatmapDialog from './components/PnlHeatmapDialog';
 import QqqTemperatureSection from './components/QqqTemperatureSection';
+import AccountPerformanceDialog from './components/AccountPerformanceDialog';
 import {
   formatDateTime,
   formatMoney,
@@ -925,6 +926,14 @@ export default function App() {
   const [qqqData, setQqqData] = useState(null);
   const [qqqLoading, setQqqLoading] = useState(false);
   const [qqqError, setQqqError] = useState(null);
+  const [performanceDataByAccount, setPerformanceDataByAccount] = useState({});
+  const [performanceDialogState, setPerformanceDialogState] = useState({
+    open: false,
+    loading: false,
+    error: null,
+    accountId: null,
+    period: 'all',
+  });
   const { loading, data, error } = useSummaryData(activeAccountId, refreshKey);
 
   const accounts = useMemo(() => data?.accounts ?? [], [data?.accounts]);
@@ -969,6 +978,58 @@ export default function App() {
     [setActiveAccountId, setSelectedAccountState]
   );
 
+  const handleRequestPerformance = useCallback(() => {
+    if (!selectedAccountId) {
+      return;
+    }
+    const accountId = selectedAccountId;
+    if (selectedPerformanceData) {
+      setPerformanceDialogState({ open: true, loading: false, error: null, accountId, period: 'all' });
+      return;
+    }
+    setPerformanceDialogState({ open: false, loading: true, error: null, accountId, period: 'all' });
+    getAccountPerformance(accountId)
+      .then((result) => {
+        setPerformanceDataByAccount((prev) => ({ ...prev, [accountId]: result }));
+        setPerformanceDialogState({ open: true, loading: false, error: null, accountId, period: 'all' });
+      })
+      .catch((requestError) => {
+        const message =
+          requestError && requestError instanceof Error
+            ? requestError.message
+            : 'Failed to load performance data.';
+        setPerformanceDialogState({ open: true, loading: false, error: message, accountId, period: 'all' });
+      });
+  }, [selectedAccountId, selectedPerformanceData]);
+
+  const handleClosePerformance = useCallback(() => {
+    setPerformanceDialogState((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  const handlePerformancePeriodChange = useCallback((nextPeriod) => {
+    setPerformanceDialogState((prev) => ({ ...prev, period: nextPeriod || 'all' }));
+  }, []);
+
+  const handleRetryPerformance = useCallback(() => {
+    const targetAccountId = performanceDialogState.accountId || selectedAccountId;
+    if (!targetAccountId) {
+      return;
+    }
+    setPerformanceDialogState((prev) => ({ ...prev, loading: true, error: null, accountId: targetAccountId }));
+    getAccountPerformance(targetAccountId)
+      .then((result) => {
+        setPerformanceDataByAccount((prev) => ({ ...prev, [targetAccountId]: result }));
+        setPerformanceDialogState((prev) => ({ ...prev, open: true, loading: false, error: null }));
+      })
+      .catch((requestError) => {
+        const message =
+          requestError && requestError instanceof Error
+            ? requestError.message
+            : 'Failed to load performance data.';
+        setPerformanceDialogState((prev) => ({ ...prev, loading: false, error: message, open: true }));
+      });
+  }, [performanceDialogState.accountId, selectedAccountId]);
+
   const selectedAccountInfo = useMemo(() => {
     if (!selectedAccount || selectedAccount === 'all') {
       return null;
@@ -984,6 +1045,34 @@ export default function App() {
       }) || null
     );
   }, [accounts, selectedAccount]);
+  const selectedAccountId = selectedAccountInfo ? selectedAccountInfo.id : null;
+  const selectedPerformanceData = useMemo(() => {
+    if (!selectedAccountId) {
+      return null;
+    }
+    return performanceDataByAccount[selectedAccountId] || null;
+  }, [performanceDataByAccount, selectedAccountId]);
+  const performanceButtonLoading = useMemo(() => {
+    if (!selectedAccountId) {
+      return false;
+    }
+    return (
+      performanceDialogState.loading &&
+      !performanceDialogState.open &&
+      performanceDialogState.accountId === selectedAccountId
+    );
+  }, [
+    performanceDialogState.loading,
+    performanceDialogState.open,
+    performanceDialogState.accountId,
+    selectedAccountId,
+  ]);
+  const performanceDialogData = useMemo(() => {
+    if (!performanceDialogState.accountId) {
+      return null;
+    }
+    return performanceDataByAccount[performanceDialogState.accountId] || null;
+  }, [performanceDialogState.accountId, performanceDataByAccount]);
   const rawPositions = useMemo(() => data?.positions ?? [], [data?.positions]);
   const balances = data?.balances || null;
   const accountBalances = data?.accountBalances ?? EMPTY_OBJECT;
@@ -1063,6 +1152,19 @@ export default function App() {
       setCurrencyView(currencyOptions[0].value);
     }
   }, [currencyOptions, currencyView]);
+
+  useEffect(() => {
+    if (!selectedAccountId) {
+      setPerformanceDialogState({ open: false, loading: false, error: null, accountId: null, period: 'all' });
+      return;
+    }
+    setPerformanceDialogState((prev) => {
+      if (prev.accountId && prev.accountId !== selectedAccountId && prev.open) {
+        return { ...prev, open: false, period: 'all', error: null };
+      }
+      return prev;
+    });
+  }, [selectedAccountId]);
 
   const balancePnlSummaries = useMemo(() => buildBalancePnlMap(balances), [balances]);
   const positionPnlSummaries = useMemo(() => buildPnlSummaries(positions), [positions]);
@@ -1296,6 +1398,8 @@ export default function App() {
   const qqqSectionTitle = selectedAccountInfo?.investmentModel ? 'Investment Model' : 'QQQ temperature';
 
   const showingAllAccounts = selectedAccount === 'all';
+  const hasPerformanceData = Boolean(selectedPerformanceData);
+  const performancePeriod = performanceDialogState.period || 'all';
 
   const fetchQqqTemperature = useCallback(() => {
     if (qqqLoading) {
@@ -1561,6 +1665,9 @@ export default function App() {
             chatUrl={selectedAccountChatUrl}
             showQqqTemperature={showingAllAccounts}
             qqqSummary={qqqSummary}
+            onShowPerformance={!showingAllAccounts && selectedAccountId ? handleRequestPerformance : null}
+            performanceLoading={!showingAllAccounts ? performanceButtonLoading : false}
+            hasPerformanceData={!showingAllAccounts ? hasPerformanceData : false}
           />
         )}
 
@@ -1597,6 +1704,17 @@ export default function App() {
           isFilteredView={!showingAllAccounts}
           missingAccounts={peopleMissingAccounts}
           asOf={asOf}
+        />
+      )}
+      {performanceDialogState.open && (
+        <AccountPerformanceDialog
+          data={performanceDialogData}
+          onClose={handleClosePerformance}
+          period={performancePeriod}
+          onPeriodChange={handlePerformancePeriodChange}
+          loading={performanceDialogState.loading}
+          error={performanceDialogState.error}
+          onRetry={handleRetryPerformance}
         />
       )}
       {pnlBreakdownMode && (

--- a/client/src/api/questrade.js
+++ b/client/src/api/questrade.js
@@ -15,6 +15,16 @@ function buildQqqTemperatureUrl() {
   return url.toString();
 }
 
+function buildPerformanceUrl(accountId) {
+  if (!accountId) {
+    throw new Error('An accountId is required to load performance data');
+  }
+  const base = API_BASE_URL.replace(/\/$/, '');
+  const encodedId = encodeURIComponent(accountId);
+  const url = new URL(`/api/accounts/${encodedId}/performance`, base);
+  return url.toString();
+}
+
 export async function getSummary(accountId) {
   const response = await fetch(buildUrl(accountId));
   if (!response.ok) {
@@ -29,6 +39,15 @@ export async function getQqqTemperature() {
   if (!response.ok) {
     const text = await response.text();
     throw new Error(text || 'Failed to load QQQ temperature data');
+  }
+  return response.json();
+}
+
+export async function getAccountPerformance(accountId) {
+  const response = await fetch(buildPerformanceUrl(accountId));
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || 'Failed to load account performance data');
   }
   return response.json();
 }

--- a/client/src/components/AccountPerformanceDialog.jsx
+++ b/client/src/components/AccountPerformanceDialog.jsx
@@ -1,0 +1,356 @@
+import { useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import {
+  formatDate,
+  formatMoney,
+  formatSignedMoney,
+  formatSignedPercent,
+  classifyPnL,
+} from '../utils/formatters';
+import {
+  PERFORMANCE_PERIOD_OPTIONS,
+  computePerformanceSummary,
+  sliceTimeline,
+  buildChartPoints,
+} from '../utils/performance';
+
+const CHART_WIDTH = 560;
+const CHART_HEIGHT = 260;
+const CHART_PADDING = { top: 24, right: 24, bottom: 36, left: 48 };
+
+function buildChartMetrics(points) {
+  if (!points || points.length === 0) {
+    return null;
+  }
+  const values = points.map((point) => point.value);
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+  const range = maxValue - minValue;
+  const padding = range === 0 ? Math.max(1, Math.abs(maxValue) * 0.1) : range * 0.1;
+  const minDomain = minValue - padding;
+  const maxDomain = maxValue + padding;
+  const domainRange = maxDomain - minDomain || 1;
+  const innerWidth = CHART_WIDTH - CHART_PADDING.left - CHART_PADDING.right;
+  const innerHeight = CHART_HEIGHT - CHART_PADDING.top - CHART_PADDING.bottom;
+
+  const metrics = points.map((point, index) => {
+    const ratio = points.length === 1 ? 0.5 : index / (points.length - 1);
+    const x = CHART_PADDING.left + innerWidth * ratio;
+    const normalized = (point.value - minDomain) / domainRange;
+    const clamped = Number.isFinite(normalized) ? Math.max(0, Math.min(1, normalized)) : 0.5;
+    const y = CHART_PADDING.top + innerHeight * (1 - clamped);
+    return { ...point, x, y };
+  });
+
+  const yFor = (value) => {
+    const normalized = (value - minDomain) / domainRange;
+    const clamped = Number.isFinite(normalized) ? Math.max(0, Math.min(1, normalized)) : 0.5;
+    return CHART_PADDING.top + innerHeight * (1 - clamped);
+  };
+
+  return {
+    points: metrics,
+    yFor,
+    minDomain,
+    maxDomain,
+  };
+}
+
+function PerformanceChart({ points }) {
+  const chartMetrics = useMemo(() => buildChartMetrics(points), [points]);
+
+  if (!chartMetrics) {
+    return (
+      <div className="performance-dialog__chart performance-dialog__chart--empty">
+        <p>No timeline data is available for this period.</p>
+      </div>
+    );
+  }
+
+  const { points: chartPoints, yFor } = chartMetrics;
+  const hasMultiplePoints = chartPoints.length > 1;
+  const pathD = hasMultiplePoints
+    ? chartPoints
+        .map((point, index) => {
+          const prefix = index === 0 ? 'M' : 'L';
+          return `${prefix}${point.x.toFixed(2)} ${point.y.toFixed(2)}`;
+        })
+        .join(' ')
+    : `M${chartPoints[0].x.toFixed(2)} ${chartPoints[0].y.toFixed(2)}`;
+
+  const latestPoint = chartPoints[chartPoints.length - 1];
+
+  const guideValues = [chartMetrics.minDomain, chartMetrics.maxDomain];
+  const guides = guideValues.map((value) => ({ value, y: yFor(value) }));
+
+  return (
+    <div className="performance-dialog__chart">
+      <svg
+        className="performance-dialog__chart-svg"
+        viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+        role="img"
+        aria-label="Account value over time"
+      >
+        <rect
+          className="performance-dialog__chart-surface"
+          x="0"
+          y="0"
+          width={CHART_WIDTH}
+          height={CHART_HEIGHT}
+        />
+        <path className="performance-dialog__chart-line" d={pathD} />
+        {chartPoints.map((point) => (
+          <circle
+            key={point.date}
+            cx={point.x}
+            cy={point.y}
+            r={point.date === latestPoint.date ? 5 : 3}
+            className={
+              point.date === latestPoint.date
+                ? 'performance-dialog__chart-marker performance-dialog__chart-marker--latest'
+                : 'performance-dialog__chart-marker'
+            }
+          />
+        ))}
+        {guides.map((guide) => (
+          <line
+            key={guide.value}
+            x1={CHART_PADDING.left}
+            x2={CHART_WIDTH - CHART_PADDING.right}
+            y1={guide.y}
+            y2={guide.y}
+            className="performance-dialog__chart-guide"
+          />
+        ))}
+      </svg>
+      <div className="performance-dialog__chart-footer">
+        <span>{chartPoints[0].date}</span>
+        <span>{chartPoints[chartPoints.length - 1].date}</span>
+      </div>
+    </div>
+  );
+}
+
+PerformanceChart.propTypes = {
+  points: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.string.isRequired,
+      value: PropTypes.number.isRequired,
+    })
+  ),
+};
+
+PerformanceChart.defaultProps = {
+  points: [],
+};
+
+export default function AccountPerformanceDialog({
+  data,
+  onClose,
+  period,
+  onPeriodChange,
+  loading,
+  error,
+  onRetry,
+}) {
+  useEffect(() => {
+    function handleKey(event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const handleOverlayClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  const summary = useMemo(() => {
+    if (!data || !Array.isArray(data.timeline)) {
+      return null;
+    }
+    return computePerformanceSummary(data.timeline, period);
+  }, [data, period]);
+
+  const chartPoints = useMemo(() => {
+    if (!data || !summary) {
+      return [];
+    }
+    const slice = sliceTimeline(data.timeline, summary.startIndex, summary.endIndex);
+    return buildChartPoints(slice);
+  }, [data, summary]);
+
+  const totalPnlTone = classifyPnL(summary ? summary.totalPnl : 0);
+  const totalPnlFormatted = summary ? formatSignedMoney(summary.totalPnl) : '—';
+  const totalPercentFormatted = summary && Number.isFinite(summary.percent)
+    ? formatSignedPercent(summary.percent, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+    : null;
+  const cagrFormatted = summary && Number.isFinite(summary.cagr)
+    ? formatSignedPercent(summary.cagr, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+    : '—';
+  const startValueFormatted = summary ? formatMoney(summary.startValue) : '—';
+  const endValueFormatted = summary ? formatMoney(summary.endValue) : '—';
+  const netFlowsFormatted = summary ? formatSignedMoney(summary.netFlows) : '—';
+  const periodLabel = PERFORMANCE_PERIOD_OPTIONS.find((option) => option.value === period)?.label || 'All';
+
+  return (
+    <div className="performance-overlay" role="presentation" onClick={handleOverlayClick}>
+      <div
+        className="performance-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="performance-dialog-title"
+      >
+        <header className="performance-dialog__header">
+          <div className="performance-dialog__heading">
+            <h2 id="performance-dialog-title">Account performance</h2>
+            {data?.startDate && data?.endDate && (
+              <p className="performance-dialog__subtitle">
+                Timeline from {formatDate(data.startDate)} to {formatDate(data.endDate)}
+              </p>
+            )}
+            {data?.baseCurrency && (
+              <p className="performance-dialog__subtitle">Values approximated in {data.baseCurrency}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            className="performance-dialog__close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="performance-dialog__body">
+          {loading && (
+            <div className="performance-dialog__status" role="status" aria-live="polite">
+              <span className="initial-loading__spinner" aria-hidden="true" />
+              <span>Calculating performance…</span>
+            </div>
+          )}
+
+          {!loading && error && (
+            <div className="performance-dialog__status performance-dialog__status--error" role="alert">
+              <p>{error}</p>
+              {onRetry && (
+                <button type="button" className="performance-dialog__retry" onClick={onRetry}>
+                  Try again
+                </button>
+              )}
+            </div>
+          )}
+
+          {!loading && !error && data && summary && (
+            <>
+              <div className="performance-dialog__metrics">
+                <div className="performance-dialog__metric">
+                  <dt>Total P&amp;L</dt>
+                  <dd>
+                    <span className={`performance-dialog__metric-value performance-dialog__metric-value--${totalPnlTone}`}>
+                      {totalPnlFormatted}
+                    </span>
+                    {totalPercentFormatted && (
+                      <span className="performance-dialog__metric-extra">({totalPercentFormatted})</span>
+                    )}
+                  </dd>
+                </div>
+                <div className="performance-dialog__metric performance-dialog__metric--cagr">
+                  <dt>CAGR</dt>
+                  <dd>
+                    <span className="performance-dialog__metric-value performance-dialog__metric-value--neutral">
+                      {cagrFormatted}
+                    </span>
+                    <label className="performance-dialog__period-select">
+                      <span className="visually-hidden">Select performance period</span>
+                      <select value={period} onChange={(event) => onPeriodChange(event.target.value)}>
+                        {PERFORMANCE_PERIOD_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  </dd>
+                </div>
+              </div>
+
+              <dl className="performance-dialog__details">
+                <div className="performance-dialog__details-row">
+                  <dt>Starting value</dt>
+                  <dd>{startValueFormatted}</dd>
+                </div>
+                <div className="performance-dialog__details-row">
+                  <dt>Net contributions</dt>
+                  <dd>{netFlowsFormatted}</dd>
+                </div>
+                <div className="performance-dialog__details-row">
+                  <dt>Ending value</dt>
+                  <dd>{endValueFormatted}</dd>
+                </div>
+                <div className="performance-dialog__details-row performance-dialog__details-row--period">
+                  <dt>Period</dt>
+                  <dd>{periodLabel}</dd>
+                </div>
+              </dl>
+
+              <PerformanceChart points={chartPoints} />
+
+              {data.warnings && data.warnings.length > 0 && (
+                <div className="performance-dialog__warnings" role="note">
+                  <p>Some data points are approximate:</p>
+                  <ul>
+                    {data.warnings.map((warning) => (
+                      <li key={warning}>{warning}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </>
+          )}
+
+          {!loading && !error && (!data || !summary) && (
+            <div className="performance-dialog__status performance-dialog__status--empty">
+              Unable to calculate performance data for this account.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+AccountPerformanceDialog.propTypes = {
+  data: PropTypes.shape({
+    baseCurrency: PropTypes.string,
+    timeline: PropTypes.arrayOf(
+      PropTypes.shape({
+        date: PropTypes.string.isRequired,
+        value: PropTypes.number,
+        netFlows: PropTypes.number,
+      })
+    ),
+    warnings: PropTypes.arrayOf(PropTypes.string),
+    startDate: PropTypes.string,
+    endDate: PropTypes.string,
+  }),
+  onClose: PropTypes.func.isRequired,
+  period: PropTypes.string.isRequired,
+  onPeriodChange: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+  error: PropTypes.string,
+  onRetry: PropTypes.func,
+};
+
+AccountPerformanceDialog.defaultProps = {
+  data: null,
+  loading: false,
+  error: null,
+  onRetry: null,
+};

--- a/client/src/utils/performance.js
+++ b/client/src/utils/performance.js
@@ -1,0 +1,214 @@
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DAYS_PER_YEAR = 365.25;
+
+export const PERFORMANCE_PERIOD_OPTIONS = [
+  { value: 'all', label: 'All', days: null },
+  { value: '1d', label: 'Last Day', days: 1 },
+  { value: '1w', label: 'Last Week', days: 7 },
+  { value: '1m', label: 'Last Month', days: 30 },
+  { value: '1y', label: 'Last Year', days: 365 },
+];
+
+function parseDate(value) {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isNaN(time) ? null : new Date(time);
+  }
+  const str = String(value).trim();
+  if (!str) {
+    return null;
+  }
+  const parsed = new Date(`${str}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed;
+}
+
+function toDateKey(date) {
+  const parsed = parseDate(date);
+  if (!parsed) {
+    return null;
+  }
+  return parsed.toISOString().slice(0, 10);
+}
+
+function findStartIndex(timeline, boundary) {
+  const boundaryDate = parseDate(boundary);
+  if (!boundaryDate) {
+    return 0;
+  }
+  for (let i = 0; i < timeline.length; i += 1) {
+    const entryDate = parseDate(timeline[i] && timeline[i].date);
+    if (entryDate && entryDate >= boundaryDate) {
+      return i;
+    }
+  }
+  return 0;
+}
+
+export function getTimelineWindow(timeline, period) {
+  if (!Array.isArray(timeline) || timeline.length === 0) {
+    return null;
+  }
+  const normalizedPeriod = period || 'all';
+  const endIndex = timeline.length - 1;
+  if (normalizedPeriod === 'all') {
+    return { startIndex: 0, endIndex };
+  }
+  const definition = PERFORMANCE_PERIOD_OPTIONS.find((option) => option.value === normalizedPeriod);
+  if (!definition || !definition.days) {
+    return { startIndex: 0, endIndex };
+  }
+  const endDate = parseDate(timeline[endIndex].date);
+  if (!endDate) {
+    return { startIndex: 0, endIndex };
+  }
+  const boundary = new Date(endDate.getTime() - definition.days * MS_PER_DAY);
+  const boundaryKey = toDateKey(boundary);
+  const startIndex = findStartIndex(timeline, boundaryKey);
+  return { startIndex, endIndex };
+}
+
+function sumFlows(timeline, startIndex, endIndex) {
+  let total = 0;
+  let positive = 0;
+  for (let i = startIndex; i <= endIndex; i += 1) {
+    const flow = Number(timeline[i] && timeline[i].netFlows);
+    if (!Number.isFinite(flow) || flow === 0) {
+      continue;
+    }
+    total += flow;
+    if (flow > 0) {
+      positive += flow;
+    }
+  }
+  return { total, positive };
+}
+
+function evaluateXirr(rate, cashFlows, referenceDate) {
+  const base = 1 + rate;
+  if (base <= 0) {
+    return { npv: Number.POSITIVE_INFINITY, derivative: Number.POSITIVE_INFINITY };
+  }
+  let npv = 0;
+  let derivative = 0;
+  const origin = referenceDate.getTime();
+  cashFlows.forEach(({ date, amount }) => {
+    const days = (date.getTime() - origin) / MS_PER_DAY;
+    const fraction = days / DAYS_PER_YEAR;
+    const discount = base ** fraction;
+    npv += amount / discount;
+    derivative -= (fraction * amount) / (discount * base);
+  });
+  return { npv, derivative };
+}
+
+function computeXirr(cashFlows) {
+  if (!Array.isArray(cashFlows) || cashFlows.length < 2) {
+    return null;
+  }
+  const positives = cashFlows.some((flow) => flow.amount > 0);
+  const negatives = cashFlows.some((flow) => flow.amount < 0);
+  if (!positives || !negatives) {
+    return null;
+  }
+  const referenceDate = cashFlows[0].date;
+  let rate = 0.1;
+  for (let iteration = 0; iteration < 100; iteration += 1) {
+    const { npv, derivative } = evaluateXirr(rate, cashFlows, referenceDate);
+    if (!Number.isFinite(npv) || !Number.isFinite(derivative)) {
+      break;
+    }
+    if (Math.abs(npv) < 1e-7) {
+      return rate;
+    }
+    if (Math.abs(derivative) < 1e-9) {
+      break;
+    }
+    const nextRate = rate - npv / derivative;
+    if (!Number.isFinite(nextRate)) {
+      break;
+    }
+    if (nextRate <= -0.9999) {
+      rate = (rate - 0.9999) / 2;
+    } else {
+      rate = nextRate;
+    }
+  }
+  return null;
+}
+
+export function computePerformanceSummary(timeline, period) {
+  const window = getTimelineWindow(timeline, period);
+  if (!window) {
+    return null;
+  }
+  const { startIndex, endIndex } = window;
+  if (startIndex > endIndex) {
+    return null;
+  }
+  const startValue = startIndex > 0 ? Number(timeline[startIndex - 1].value) || 0 : 0;
+  const endValue = Number(timeline[endIndex].value) || 0;
+  const { total: netFlows, positive: positiveFlows } = sumFlows(timeline, startIndex, endIndex);
+  const totalPnl = endValue - startValue - netFlows;
+  const invested = startValue + positiveFlows;
+  const percent = invested > 0 ? (totalPnl / invested) * 100 : startValue !== 0 ? (totalPnl / Math.abs(startValue)) * 100 : null;
+
+  const startDate = parseDate(timeline[startIndex].date);
+  const endDate = parseDate(timeline[endIndex].date);
+  let cagr = null;
+  if (startDate && endDate && endDate > startDate) {
+    const cashFlows = [];
+    cashFlows.push({ date: startDate, amount: -startValue });
+    for (let i = startIndex; i <= endIndex; i += 1) {
+      const flow = Number(timeline[i].netFlows);
+      if (!Number.isFinite(flow) || flow === 0) {
+        continue;
+      }
+      const flowDate = parseDate(timeline[i].date);
+      if (!flowDate) {
+        continue;
+      }
+      cashFlows.push({ date: flowDate, amount: -flow });
+    }
+    cashFlows.push({ date: endDate, amount: endValue });
+    const rate = computeXirr(cashFlows);
+    if (rate !== null) {
+      cagr = rate * 100;
+    }
+  }
+
+  return {
+    startIndex,
+    endIndex,
+    startValue,
+    endValue,
+    netFlows,
+    totalPnl,
+    percent,
+    cagr,
+    startDate: startDate ? toDateKey(startDate) : null,
+    endDate: endDate ? toDateKey(endDate) : null,
+  };
+}
+
+export function sliceTimeline(timeline, startIndex, endIndex) {
+  if (!Array.isArray(timeline) || startIndex < 0 || endIndex < startIndex) {
+    return [];
+  }
+  return timeline.slice(startIndex, endIndex + 1);
+}
+
+export function buildChartPoints(timelineSlice) {
+  if (!Array.isArray(timelineSlice) || timelineSlice.length === 0) {
+    return [];
+  }
+  return timelineSlice.map((entry) => ({
+    date: entry.date,
+    value: Number(entry.value) || 0,
+  }));
+}

--- a/client/src/utils/performance.test.js
+++ b/client/src/utils/performance.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getTimelineWindow,
+  computePerformanceSummary,
+  sliceTimeline,
+  buildChartPoints,
+} from './performance';
+
+describe('getTimelineWindow', () => {
+  it('returns the full range when requesting all data', () => {
+    const timeline = [
+      { date: '2024-01-01', value: 0, netFlows: 0 },
+      { date: '2024-01-05', value: 100, netFlows: 0 },
+      { date: '2024-01-10', value: 200, netFlows: 0 },
+    ];
+
+    expect(getTimelineWindow(timeline, 'all')).toEqual({ startIndex: 0, endIndex: 2 });
+  });
+
+  it('resolves a rolling window for recent periods', () => {
+    const timeline = [
+      { date: '2024-01-01', value: 0, netFlows: 0 },
+      { date: '2024-01-05', value: 100, netFlows: 0 },
+      { date: '2024-01-10', value: 200, netFlows: 0 },
+      { date: '2024-01-15', value: 300, netFlows: 0 },
+    ];
+
+    expect(getTimelineWindow(timeline, '1w')).toEqual({ startIndex: 2, endIndex: 3 });
+  });
+
+  it('returns null when the timeline is empty', () => {
+    expect(getTimelineWindow([], '1w')).toBeNull();
+  });
+});
+
+describe('sliceTimeline', () => {
+  it('returns an inclusive slice across the provided bounds', () => {
+    const timeline = [
+      { date: '2024-01-01', value: 0, netFlows: 0 },
+      { date: '2024-01-02', value: 50, netFlows: 0 },
+      { date: '2024-01-03', value: 75, netFlows: 0 },
+    ];
+
+    expect(sliceTimeline(timeline, 1, 2)).toEqual([
+      { date: '2024-01-02', value: 50, netFlows: 0 },
+      { date: '2024-01-03', value: 75, netFlows: 0 },
+    ]);
+  });
+
+  it('returns an empty array when the bounds are invalid', () => {
+    const timeline = [
+      { date: '2024-01-01', value: 0, netFlows: 0 },
+      { date: '2024-01-02', value: 50, netFlows: 0 },
+    ];
+
+    expect(sliceTimeline(timeline, 2, 1)).toEqual([]);
+  });
+});
+
+describe('buildChartPoints', () => {
+  it('normalizes the timeline data for chart rendering', () => {
+    const timeline = [
+      { date: '2024-01-01', value: '100.5' },
+      { date: '2024-01-02', value: null },
+    ];
+
+    expect(buildChartPoints(timeline)).toEqual([
+      { date: '2024-01-01', value: 100.5 },
+      { date: '2024-01-02', value: 0 },
+    ]);
+  });
+
+  it('returns an empty array when no data is provided', () => {
+    expect(buildChartPoints(null)).toEqual([]);
+  });
+});
+
+describe('computePerformanceSummary', () => {
+  it('calculates totals and CAGR across the full timeline', () => {
+    const timeline = [
+      { date: '2024-01-01', value: 0, netFlows: 0 },
+      { date: '2024-01-02', value: 1000, netFlows: 1000 },
+      { date: '2025-01-02', value: 1100, netFlows: 0 },
+    ];
+
+    const summary = computePerformanceSummary(timeline, 'all');
+
+    expect(summary).not.toBeNull();
+    expect(summary.startIndex).toBe(0);
+    expect(summary.endIndex).toBe(2);
+    expect(summary.startValue).toBe(0);
+    expect(summary.endValue).toBe(1100);
+    expect(summary.netFlows).toBe(1000);
+    expect(summary.totalPnl).toBe(100);
+    expect(summary.percent).toBeCloseTo(10, 5);
+    expect(summary.cagr).toBeCloseTo(9.9785, 4);
+    expect(summary.startDate).toBe('2024-01-01');
+    expect(summary.endDate).toBe('2025-01-02');
+  });
+
+  it('uses the previous value as the baseline for partial windows', () => {
+    const timeline = [
+      { date: '2024-01-01', value: 0, netFlows: 0 },
+      { date: '2024-01-10', value: 1000, netFlows: 1000 },
+      { date: '2024-12-01', value: 1200, netFlows: 0 },
+      { date: '2024-12-20', value: 1250, netFlows: 0 },
+      { date: '2025-01-10', value: 1350, netFlows: 0 },
+    ];
+
+    const summary = computePerformanceSummary(timeline, '1m');
+
+    expect(summary).not.toBeNull();
+    expect(summary.startIndex).toBe(3);
+    expect(summary.endIndex).toBe(4);
+    expect(summary.startValue).toBe(1200);
+    expect(summary.endValue).toBe(1350);
+    expect(summary.netFlows).toBe(0);
+    expect(summary.totalPnl).toBe(150);
+    expect(summary.percent).toBeCloseTo(12.5, 5);
+    expect(summary.cagr).toBeGreaterThan(0);
+    expect(Number.isFinite(summary.cagr)).toBe(true);
+  });
+
+  it('returns null when the timeline cannot be evaluated', () => {
+    expect(computePerformanceSummary([], 'all')).toBeNull();
+  });
+});

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'node',
+    clearMocks: true,
+  },
 })

--- a/server/src/accountPerformance.js
+++ b/server/src/accountPerformance.js
@@ -1,0 +1,510 @@
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+let yahooFinance = null;
+let yahooFinanceLoadError = null;
+
+try {
+  // yahoo-finance2 is an ESM module that exposes its API via a default export.
+  // eslint-disable-next-line global-require
+  yahooFinance = require('yahoo-finance2').default;
+  if (yahooFinance && typeof yahooFinance.suppressNotices === 'function') {
+    yahooFinance.suppressNotices(['ripHistorical']);
+  }
+} catch (error) {
+  yahooFinanceLoadError = error instanceof Error ? error : new Error(String(error));
+  yahooFinance = null;
+}
+
+const MISSING_DEPENDENCY_MESSAGE =
+  'The "yahoo-finance2" package is required to calculate account performance data. ' +
+  'Run `npm install` inside the server directory to install it.';
+
+class MissingDependencyError extends Error {
+  constructor(message, cause) {
+    super(message);
+    this.name = 'MissingDependencyError';
+    this.code = 'MISSING_DEPENDENCY';
+    if (cause) {
+      this.cause = cause;
+    }
+  }
+}
+
+if (!yahooFinance && yahooFinanceLoadError) {
+  console.warn('[Account performance] yahoo-finance2 dependency not found:', yahooFinanceLoadError.message);
+  console.warn('[Account performance]', MISSING_DEPENDENCY_MESSAGE);
+}
+
+function ensureYahooFinance() {
+  if (!yahooFinance) {
+    throw new MissingDependencyError(MISSING_DEPENDENCY_MESSAGE, yahooFinanceLoadError);
+  }
+  return yahooFinance;
+}
+
+function parseDate(value) {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isNaN(time) ? null : new Date(time);
+  }
+  const str = String(value).trim();
+  if (!str) {
+    return null;
+  }
+  const parsed = new Date(`${str}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed;
+}
+
+function parseDateTime(value) {
+  if (!value) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date;
+}
+
+function formatDate(date) {
+  const parsed = parseDate(date);
+  if (!parsed) {
+    return null;
+  }
+  return parsed.toISOString().slice(0, 10);
+}
+
+function addDays(date, days) {
+  const parsed = parseDate(date);
+  if (!parsed) {
+    return null;
+  }
+  return new Date(parsed.getTime() + days * MS_PER_DAY);
+}
+
+function buildDateRange(startDate, endDate) {
+  const start = parseDate(startDate);
+  const end = parseDate(endDate);
+  if (!start || !end || end < start) {
+    return [];
+  }
+  const days = Math.floor((end.getTime() - start.getTime()) / MS_PER_DAY);
+  const dates = [];
+  for (let i = 0; i <= days; i += 1) {
+    const current = new Date(start.getTime() + i * MS_PER_DAY);
+    dates.push(current.toISOString().slice(0, 10));
+  }
+  return dates;
+}
+
+function safeNumber(value, fallback = 0) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  return num;
+}
+
+async function fetchHistoricalSeries(ticker, startDate, endDate) {
+  const finance = ensureYahooFinance();
+  const period1 = formatDate(startDate);
+  const period2 = formatDate(addDays(endDate, 1));
+  if (!period1 || !period2) {
+    return new Map();
+  }
+  try {
+    const quotes = await finance.historical(ticker, {
+      period1,
+      period2,
+      interval: '1d',
+    });
+    const entries = Array.isArray(quotes) ? quotes : [];
+    const map = new Map();
+    entries.forEach((entry) => {
+      const date = formatDate(entry && entry.date);
+      const close = entry && (entry.adjClose ?? entry.close ?? entry.close_);
+      const value = safeNumber(close, null);
+      if (!date || value === null || value <= 0) {
+        return;
+      }
+      map.set(date, value);
+    });
+    return map;
+  } catch (error) {
+    console.warn('[Account performance] Failed to fetch history for', ticker, error.message || error);
+    return new Map();
+  }
+}
+
+async function fetchFxSeries(currency, baseCurrency, startDate, endDate) {
+  const upperCurrency = String(currency || '').toUpperCase();
+  const upperBase = String(baseCurrency || '').toUpperCase();
+  if (!upperCurrency || !upperBase || upperCurrency === upperBase) {
+    const map = new Map();
+    buildDateRange(startDate, endDate).forEach((date) => {
+      map.set(date, 1);
+    });
+    return map;
+  }
+  const ticker = `${upperCurrency}${upperBase}=X`;
+  const series = await fetchHistoricalSeries(ticker, startDate, endDate);
+  if (!series.size) {
+    // Fallback to an implied parity when no FX data is available.
+    console.warn('[Account performance] Missing FX series for', upperCurrency, '→', upperBase);
+    const fallback = new Map();
+    buildDateRange(startDate, endDate).forEach((date) => {
+      fallback.set(date, 1);
+    });
+    return fallback;
+  }
+  return series;
+}
+
+function normalizeExecution(execution) {
+  const dateTime = parseDateTime(execution && execution.executionTime);
+  const date = formatDate(dateTime);
+  if (!date) {
+    return null;
+  }
+  const side = String(execution && execution.side ? execution.side : '').toLowerCase();
+  let direction = 0;
+  if (side === 'buy' || side === 'cover') {
+    direction = 1;
+  } else if (side === 'sell' || side === 'short') {
+    direction = -1;
+  }
+  if (direction === 0) {
+    return null;
+  }
+  const quantity = safeNumber(execution.quantity || execution.execShares || execution.enteredQuantity, 0);
+  if (quantity === 0) {
+    return null;
+  }
+  const price = safeNumber(execution.price || execution.avgPrice || execution.averagePrice || execution.executionPrice, 0);
+  const gross = Math.abs(price * quantity);
+  const netAmount = safeNumber(execution.netAmount, gross);
+  const amount = Math.abs(netAmount) > 0 ? Math.abs(netAmount) : gross;
+  return {
+    symbolId: execution.symbolId || execution.symbolID || execution.symbol || null,
+    symbol: execution.symbol || null,
+    currency: String(execution.currency || execution.payableCurrency || 'CAD').toUpperCase(),
+    date,
+    direction,
+    quantity,
+    amount,
+  };
+}
+
+function normalizeSymbolMetadata(symbolDetails, execution) {
+  const symbolId = execution.symbolId;
+  const detail = symbolDetails && symbolId != null ? symbolDetails[symbolId] : null;
+  const ticker = detail && detail.symbol ? String(detail.symbol).trim() : execution.symbol ? String(execution.symbol).trim() : null;
+  const currency = detail && detail.currency ? String(detail.currency).toUpperCase() : execution.currency;
+  if (!ticker) {
+    return null;
+  }
+  return {
+    symbolId,
+    ticker,
+    currency: currency || 'CAD',
+  };
+}
+
+function buildTrades(executions, symbolDetails) {
+  const trades = [];
+  const metadataBySymbol = new Map();
+  executions.forEach((raw) => {
+    const normalized = normalizeExecution(raw);
+    if (!normalized || !normalized.symbolId) {
+      return;
+    }
+    const meta = normalizeSymbolMetadata(symbolDetails, normalized);
+    if (!meta) {
+      return;
+    }
+    metadataBySymbol.set(normalized.symbolId, meta);
+    trades.push({
+      symbolId: normalized.symbolId,
+      date: normalized.date,
+      currency: meta.currency,
+      ticker: meta.ticker,
+      quantityChange: normalized.direction * normalized.quantity,
+      contribution: normalized.direction > 0 ? normalized.amount : -normalized.amount,
+    });
+  });
+  trades.sort((a, b) => {
+    if (a.date === b.date) {
+      if (a.symbolId === b.symbolId) {
+        return 0;
+      }
+      return a.symbolId < b.symbolId ? -1 : 1;
+    }
+    return a.date < b.date ? -1 : 1;
+  });
+  return { trades, metadataBySymbol };
+}
+
+function collectCurrencies(metadataBySymbol) {
+  const set = new Set();
+  metadataBySymbol.forEach((meta) => {
+    if (meta && meta.currency) {
+      set.add(String(meta.currency).toUpperCase());
+    }
+  });
+  return Array.from(set);
+}
+
+function collectTickers(metadataBySymbol) {
+  const set = new Set();
+  metadataBySymbol.forEach((meta) => {
+    if (meta && meta.ticker) {
+      set.add(meta.ticker);
+    }
+  });
+  return Array.from(set);
+}
+
+function buildTradesByDate(trades) {
+  const map = new Map();
+  trades.forEach((trade) => {
+    if (!map.has(trade.date)) {
+      map.set(trade.date, []);
+    }
+    map.get(trade.date).push(trade);
+  });
+  return map;
+}
+
+function buildPriceMaps(priceSeriesByTicker) {
+  const map = new Map();
+  Object.keys(priceSeriesByTicker).forEach((ticker) => {
+    const series = priceSeriesByTicker[ticker];
+    if (series instanceof Map) {
+      map.set(ticker, series);
+    }
+  });
+  return map;
+}
+
+function buildFxMaps(fxSeriesByCurrency) {
+  const map = new Map();
+  Object.keys(fxSeriesByCurrency).forEach((currency) => {
+    const series = fxSeriesByCurrency[currency];
+    if (series instanceof Map) {
+      map.set(currency, series);
+    }
+  });
+  return map;
+}
+
+function resolveFxRate(currency, date, fxMaps, lastFxRates, baseCurrency) {
+  const upperCurrency = String(currency || '').toUpperCase();
+  if (!upperCurrency || upperCurrency === baseCurrency) {
+    return 1;
+  }
+  if (fxMaps.has(upperCurrency)) {
+    const map = fxMaps.get(upperCurrency);
+    if (map.has(date)) {
+      const rate = safeNumber(map.get(date), null);
+      if (rate !== null && rate > 0) {
+        lastFxRates.set(upperCurrency, rate);
+        return rate;
+      }
+    }
+  }
+  if (lastFxRates.has(upperCurrency)) {
+    return lastFxRates.get(upperCurrency);
+  }
+  return 1;
+}
+
+function resolvePrice(symbolId, ticker, date, priceMaps, lastPrices) {
+  if (priceMaps.has(ticker)) {
+    const map = priceMaps.get(ticker);
+    if (map.has(date)) {
+      const price = safeNumber(map.get(date), null);
+      if (price !== null && price > 0) {
+        lastPrices.set(symbolId, price);
+        return price;
+      }
+    }
+  }
+  if (lastPrices.has(symbolId)) {
+    return lastPrices.get(symbolId);
+  }
+  return null;
+}
+
+function roundValue(value) {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function buildTimeline({
+  trades,
+  metadataBySymbol,
+  priceMaps,
+  fxMaps,
+  startDate,
+  endDate,
+  baseCurrency,
+}) {
+  const dates = buildDateRange(startDate, endDate);
+  if (!dates.length) {
+    return { timeline: [], warnings: [] };
+  }
+  const tradesByDate = buildTradesByDate(trades);
+  const holdings = new Map();
+  const lastPrices = new Map();
+  const lastFxRates = new Map();
+  const warnings = new Set();
+  const timeline = [];
+
+  metadataBySymbol.forEach((meta) => {
+    if (meta && meta.currency && meta.currency.toUpperCase() === baseCurrency) {
+      lastFxRates.set(meta.currency.toUpperCase(), 1);
+    }
+  });
+
+  dates.forEach((date) => {
+    // Refresh FX rates with any data for the current date.
+    fxMaps.forEach((series, currency) => {
+      if (currency === baseCurrency) {
+        lastFxRates.set(currency, 1);
+        return;
+      }
+      if (series.has(date)) {
+        const rate = safeNumber(series.get(date), null);
+        if (rate !== null && rate > 0) {
+          lastFxRates.set(currency, rate);
+        }
+      }
+    });
+
+    // Refresh prices for the current date.
+    metadataBySymbol.forEach((meta, symbolId) => {
+      const price = resolvePrice(symbolId, meta.ticker, date, priceMaps, lastPrices);
+      if (price !== null) {
+        lastPrices.set(symbolId, price);
+      }
+    });
+
+    const tradesForDate = tradesByDate.get(date) || [];
+    let netContributionBase = 0;
+
+    tradesForDate.forEach((trade) => {
+      const currentQuantity = holdings.get(trade.symbolId) || 0;
+      const nextQuantity = currentQuantity + trade.quantityChange;
+      if (Math.abs(nextQuantity) < 1e-8) {
+        holdings.delete(trade.symbolId);
+      } else {
+        holdings.set(trade.symbolId, nextQuantity);
+      }
+      const fxRate = resolveFxRate(trade.currency, date, fxMaps, lastFxRates, baseCurrency);
+      netContributionBase += trade.contribution * fxRate;
+    });
+
+    let portfolioValue = 0;
+    holdings.forEach((quantity, symbolId) => {
+      const meta = metadataBySymbol.get(symbolId);
+      if (!meta) {
+        return;
+      }
+      const price = lastPrices.get(symbolId);
+      if (price === undefined || price === null) {
+        warnings.add(`Missing price history for ${meta.ticker}`);
+        return;
+      }
+      const fxRate = resolveFxRate(meta.currency, date, fxMaps, lastFxRates, baseCurrency);
+      portfolioValue += quantity * price * fxRate;
+    });
+
+    timeline.push({
+      date,
+      value: roundValue(portfolioValue),
+      netFlows: roundValue(netContributionBase),
+    });
+  });
+
+  return { timeline, warnings: Array.from(warnings) };
+}
+
+async function computeAccountPerformance({
+  executions,
+  symbolDetails,
+  baseCurrency = 'CAD',
+  endDate = new Date(),
+}) {
+  if (!Array.isArray(executions) || executions.length === 0) {
+    return {
+      baseCurrency,
+      timeline: [],
+      startDate: null,
+      endDate: null,
+      warnings: [],
+    };
+  }
+
+  const { trades, metadataBySymbol } = buildTrades(executions, symbolDetails);
+  if (!trades.length || metadataBySymbol.size === 0) {
+    return {
+      baseCurrency,
+      timeline: [],
+      startDate: null,
+      endDate: null,
+      warnings: ['No executable trades with recognizable symbols were found.'],
+    };
+  }
+
+  const firstTradeDate = trades[0].date;
+  const startDate = formatDate(addDays(firstTradeDate, -1));
+  const normalizedEndDate = formatDate(endDate) || trades[trades.length - 1].date;
+
+  const tickers = collectTickers(metadataBySymbol);
+  const currencies = collectCurrencies(metadataBySymbol);
+
+  const priceSeriesByTicker = {};
+  // eslint-disable-next-line no-restricted-syntax
+  for (const ticker of tickers) {
+    // eslint-disable-next-line no-await-in-loop
+    priceSeriesByTicker[ticker] = await fetchHistoricalSeries(ticker, startDate, normalizedEndDate);
+  }
+
+  const fxSeriesByCurrency = {};
+  // eslint-disable-next-line no-restricted-syntax
+  for (const currency of currencies) {
+    // eslint-disable-next-line no-await-in-loop
+    fxSeriesByCurrency[currency] = await fetchFxSeries(currency, baseCurrency, startDate, normalizedEndDate);
+  }
+
+  const priceMaps = buildPriceMaps(priceSeriesByTicker);
+  const fxMaps = buildFxMaps(fxSeriesByCurrency);
+
+  const { timeline, warnings } = buildTimeline({
+    trades,
+    metadataBySymbol,
+    priceMaps,
+    fxMaps,
+    startDate,
+    endDate: normalizedEndDate,
+    baseCurrency,
+  });
+
+  return {
+    baseCurrency,
+    timeline,
+    startDate,
+    endDate: normalizedEndDate,
+    warnings,
+  };
+}
+
+module.exports = {
+  computeAccountPerformance,
+  MissingDependencyError,
+};


### PR DESCRIPTION
## Summary
- add a vitest test script and configuration so the client bundle can run unit tests
- cover the performance timeline helpers with unit tests to verify windowing, summaries, and chart point generation

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc4d0d3300832d89fe2ca52c655f09