### PR TITLE
Implement Total P&L and net deposits for single-account view

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -743,6 +743,18 @@ textarea {
   border-bottom: 1px dotted var(--color-border-strong);
 }
 
+.equity-card__metric-separator {
+  padding: 8px 0 4px;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  letter-spacing: 4px;
+}
+
+.equity-card__metric-separator span {
+  display: inline-block;
+}
+
 
 .equity-card__metric-row[data-interactive='true'] {
   cursor: pointer;

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -192,6 +192,7 @@ export default function SummaryMetrics({
   onCurrencyChange,
   balances,
   pnl,
+  netDeposits,
   asOf,
   onRefresh,
   displayTotalEquity,
@@ -219,6 +220,8 @@ export default function SummaryMetrics({
   const formattedToday = formatSignedMoney(pnl?.dayPnl ?? null);
   const formattedOpen = formatSignedMoney(pnl?.openPnl ?? null);
   const formattedTotal = formatSignedMoney(pnl?.totalPnl ?? null);
+  const hasNetDeposits = Number.isFinite(netDeposits);
+  const formattedNetDeposits = formatSignedMoney(hasNetDeposits ? netDeposits : null);
 
   const safeTotalEquity = Number.isFinite(totalEquity) ? totalEquity : null;
 
@@ -356,6 +359,14 @@ export default function SummaryMetrics({
             onActivate={onShowPnlBreakdown ? () => onShowPnlBreakdown('open') : null}
           />
           <MetricRow label="Total P&L" value={formattedTotal} tone={totalTone} />
+          {hasNetDeposits && (
+            <>
+              <div className="equity-card__metric-separator" aria-hidden="true">
+                <span>…</span>
+              </div>
+              <MetricRow label="Net deposits" value={formattedNetDeposits} tone="neutral" />
+            </>
+          )}
         </dl>
         <dl className="equity-card__metric-column">
           <MetricRow label="Total equity" value={formatMoney(totalEquity)} tone="neutral" />
@@ -396,6 +407,7 @@ SummaryMetrics.propTypes = {
     openPnl: PropTypes.number,
     totalPnl: PropTypes.number,
   }).isRequired,
+  netDeposits: PropTypes.number,
   asOf: PropTypes.string,
   onRefresh: PropTypes.func,
   displayTotalEquity: PropTypes.number,
@@ -432,4 +444,5 @@ SummaryMetrics.defaultProps = {
   chatUrl: null,
   showQqqTemperature: false,
   qqqSummary: null,
+  netDeposits: null,
 };


### PR DESCRIPTION
## Summary
- add server-side funding summary logic that walks Questrade activities, applies historical FX conversion, and exposes combined CAD totals for single accounts
- include net deposits and computed Total P&L in the summary API response for single-account requests
- surface the new data in the client summary pod with a dedicated net deposits row and ellipsis separator, and update clipboard output

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfec885694832db5fd2d54287e9723