### PR TITLE
Add total P&L and net deposit calculations for single account summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ server/token-store.json
 server/accounts.json
 server/account-beneficiaries.json
 server/data/qqq-cache/
+.cache/
 vendor/TQQQ/
 
 # Env files

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -984,6 +984,10 @@ export default function App() {
       }) || null
     );
   }, [accounts, selectedAccount]);
+  const rawPositions = useMemo(() => data?.positions ?? [], [data?.positions]);
+  const balances = data?.balances || null;
+  const accountFunding = data?.accountFunding ?? EMPTY_OBJECT;
+  const accountBalances = data?.accountBalances ?? EMPTY_OBJECT;
   const selectedAccountFunding = useMemo(() => {
     if (!selectedAccountInfo) {
       return null;
@@ -994,10 +998,6 @@ export default function App() {
     }
     return null;
   }, [selectedAccountInfo, accountFunding]);
-  const rawPositions = useMemo(() => data?.positions ?? [], [data?.positions]);
-  const balances = data?.balances || null;
-  const accountBalances = data?.accountBalances ?? EMPTY_OBJECT;
-  const accountFunding = data?.accountFunding ?? EMPTY_OBJECT;
   const investmentModelEvaluations = data?.investmentModelEvaluations ?? EMPTY_OBJECT;
   const asOf = data?.asOf || null;
 

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -229,7 +229,11 @@ export default function SummaryMetrics({
     : null;
   const formattedNetDeposits = netDepositsValue !== null ? formatMoney(netDepositsValue) : null;
 
-  const safeTotalEquity = Number.isFinite(totalEquity) ? totalEquity : null;
+  const safeTotalEquity = Number.isFinite(totalEquity)
+    ? totalEquity
+    : Number.isFinite(fundingSummary?.totalEquityCad)
+      ? fundingSummary.totalEquityCad
+      : null;
 
   const formatPnlPercent = (change) => {
     if (!Number.isFinite(change)) {
@@ -262,6 +266,7 @@ export default function SummaryMetrics({
 
   const dayPercent = formatPnlPercent(pnl?.dayPnl);
   const openPercent = formatPnlPercent(pnl?.openPnl);
+  const totalPercent = formatPnlPercent(totalPnlValue);
 
   return (
     <section className="equity-card">
@@ -364,7 +369,12 @@ export default function SummaryMetrics({
             tone={openTone}
             onActivate={onShowPnlBreakdown ? () => onShowPnlBreakdown('open') : null}
           />
-          <MetricRow label="Total P&L" value={formattedTotal} tone={totalTone} />
+          <MetricRow
+            label="Total P&L"
+            value={formattedTotal}
+            extra={totalPercent ? `(${totalPercent})` : null}
+            tone={totalTone}
+          />
           {formattedNetDeposits && <MetricRow label="Net deposits" value={formattedNetDeposits} tone="neutral" />}
         </dl>
         <dl className="equity-card__metric-column">

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -192,6 +192,7 @@ export default function SummaryMetrics({
   onCurrencyChange,
   balances,
   pnl,
+  fundingSummary,
   asOf,
   onRefresh,
   displayTotalEquity,
@@ -212,13 +213,21 @@ export default function SummaryMetrics({
   const cash = balances?.cash ?? null;
   const buyingPower = balances?.buyingPower ?? null;
 
+  const totalPnlValue = Number.isFinite(pnl?.totalPnl)
+    ? pnl.totalPnl
+    : Number.isFinite(fundingSummary?.totalPnlCad)
+      ? fundingSummary.totalPnlCad
+      : null;
   const todayTone = classifyPnL(pnl?.dayPnl);
   const openTone = classifyPnL(pnl?.openPnl);
-  const totalTone = classifyPnL(pnl?.totalPnl);
-
+  const totalTone = classifyPnL(totalPnlValue);
   const formattedToday = formatSignedMoney(pnl?.dayPnl ?? null);
   const formattedOpen = formatSignedMoney(pnl?.openPnl ?? null);
-  const formattedTotal = formatSignedMoney(pnl?.totalPnl ?? null);
+  const formattedTotal = formatSignedMoney(totalPnlValue);
+  const netDepositsValue = Number.isFinite(fundingSummary?.netDepositsCad)
+    ? fundingSummary.netDepositsCad
+    : null;
+  const formattedNetDeposits = netDepositsValue !== null ? formatMoney(netDepositsValue) : null;
 
   const safeTotalEquity = Number.isFinite(totalEquity) ? totalEquity : null;
 
@@ -356,6 +365,7 @@ export default function SummaryMetrics({
             onActivate={onShowPnlBreakdown ? () => onShowPnlBreakdown('open') : null}
           />
           <MetricRow label="Total P&L" value={formattedTotal} tone={totalTone} />
+          {formattedNetDeposits && <MetricRow label="Net deposits" value={formattedNetDeposits} tone="neutral" />}
         </dl>
         <dl className="equity-card__metric-column">
           <MetricRow label="Total equity" value={formatMoney(totalEquity)} tone="neutral" />
@@ -396,6 +406,10 @@ SummaryMetrics.propTypes = {
     openPnl: PropTypes.number,
     totalPnl: PropTypes.number,
   }).isRequired,
+  fundingSummary: PropTypes.shape({
+    netDepositsCad: PropTypes.number,
+    totalPnlCad: PropTypes.number,
+  }),
   asOf: PropTypes.string,
   onRefresh: PropTypes.func,
   displayTotalEquity: PropTypes.number,
@@ -432,4 +446,5 @@ SummaryMetrics.defaultProps = {
   chatUrl: null,
   showQqqTemperature: false,
   qqqSummary: null,
+  fundingSummary: null,
 };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -541,7 +541,12 @@ async function fetchBalances(login, accountId) {
 
 const DEBUG_TOTAL_PNL = process.env.DEBUG_TOTAL_PNL !== 'false';
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
-const MAX_ACTIVITIES_WINDOW_DAYS = 31;
+// Questrade's documentation cites a 31 day cap for the activities endpoint, but in
+// practice we receive "Argument length exceeds imposed limit" errors whenever the
+// requested range spans a full 31 calendar days. Keeping the window strictly under
+// that threshold avoids the 400 errors without materially increasing the number of
+// requests we make.
+const MAX_ACTIVITIES_WINDOW_DAYS = 30;
 const MIN_ACTIVITY_DATE = new Date('2000-01-01T00:00:00Z');
 const USD_TO_CAD_SERIES = 'DEXCAUS';
 


### PR DESCRIPTION
## Summary
- compute net deposits and total P&L for single-account requests by paging activities, valuing in-kind transfers, and converting USD flows with historical FX
- expose the calculated totals through the summary API response and use a debug flag to trace activity processing
- display the computed total P&L and net deposits in the combined CAD summary card for single accounts

## Testing
- npm --prefix client run lint

------
https://chatgpt.com/codex/tasks/task_e_68e002510034832dbba12cf0569bb202