### PR TITLE
Fix account funding memo initialization order

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -986,18 +986,20 @@ export default function App() {
   }, [accounts, selectedAccount]);
   const rawPositions = useMemo(() => data?.positions ?? [], [data?.positions]);
   const balances = data?.balances || null;
-  const accountFunding = data?.accountFunding ?? EMPTY_OBJECT;
   const accountBalances = data?.accountBalances ?? EMPTY_OBJECT;
   const selectedAccountFunding = useMemo(() => {
     if (!selectedAccountInfo) {
       return null;
     }
-    const entry = accountFunding[selectedAccountInfo.id];
-    if (entry && typeof entry === 'object') {
-      return entry;
+    const funding = data?.accountFunding;
+    if (funding && typeof funding === 'object') {
+      const entry = funding[selectedAccountInfo.id];
+      if (entry && typeof entry === 'object') {
+        return entry;
+      }
     }
     return null;
-  }, [selectedAccountInfo, accountFunding]);
+  }, [data?.accountFunding, selectedAccountInfo]);
   const investmentModelEvaluations = data?.investmentModelEvaluations ?? EMPTY_OBJECT;
   const asOf = data?.asOf || null;
 


### PR DESCRIPTION
## Summary
- ensure the selected account funding memo reads from the accountFunding data safely
- guard the memoized lookup so it returns null when no funding object is available

## Testing
- npm --prefix client run lint

------
https://chatgpt.com/codex/tasks/task_e_68e029ab16c8832db429b875ef304527