### PR TITLE
Add cagrStartDate account override support

### DIFF
--- a/server/src/accountNames.js
+++ b/server/src/accountNames.js
@@ -189,6 +189,19 @@ function applyNetDepositAdjustmentSetting(target, key, value) {
   container.netDepositAdjustment = normalized;
 }
 
+function applyCagrStartDateSetting(target, key, value) {
+  const container = ensureAccountSettingsEntry(target, key);
+  if (!container) {
+    return;
+  }
+  const normalized = normalizeDateOnly(value);
+  if (!normalized) {
+    delete container.cagrStartDate;
+    return;
+  }
+  container.cagrStartDate = normalized;
+}
+
 function normalizeDateOnly(value) {
   if (value == null) {
     return null;
@@ -421,6 +434,9 @@ function extractEntry(
     }
     if (Object.prototype.hasOwnProperty.call(entry, 'netDepositAdjustment')) {
       applyNetDepositAdjustmentSetting(settingsTarget, resolvedKey, entry.netDepositAdjustment);
+    }
+    if (Object.prototype.hasOwnProperty.call(entry, 'cagrStartDate')) {
+      applyCagrStartDateSetting(settingsTarget, resolvedKey, entry.cagrStartDate);
     }
   }
 


### PR DESCRIPTION
## Summary
- allow account settings to specify a `cagrStartDate` override and surface it on accounts
- adjust net deposit processing so single-account CAGR calculations aggregate prior cash flows at the configured start date
- include the applied start date metadata in the annualized return payload for client awareness

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e03cf0c1fc832d94feef107bc28fc7