### PR TITLE
Add invest cash evenly action

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -588,6 +588,363 @@ textarea {
   color: var(--color-text-secondary);
 }
 
+.invest-plan-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.45);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 32px 24px;
+  overflow-y: auto;
+  z-index: 1100;
+}
+
+.invest-plan-dialog {
+  background: var(--color-surface);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
+  width: min(960px, 100%);
+  max-height: 95vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.invest-plan-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 24px 24px 12px;
+  border-bottom: 1px solid var(--color-divider);
+}
+
+.invest-plan-dialog__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.invest-plan-dialog__title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.invest-plan-dialog__account {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.invest-plan-dialog__account-link {
+  font-size: 13px;
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.invest-plan-dialog__account-link:hover,
+.invest-plan-dialog__account-link:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.invest-plan-dialog__close {
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  transition: color 0.2s ease, background-color 0.2s ease, transform 0.1s ease;
+}
+
+.invest-plan-dialog__close:hover,
+.invest-plan-dialog__close:focus-visible {
+  color: var(--color-text-primary);
+  background: var(--color-surface-alt);
+  outline: none;
+}
+
+.invest-plan-dialog__close:active {
+  transform: scale(0.96);
+}
+
+.invest-plan-dialog__body {
+  flex: 1;
+  padding: 12px 24px 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.invest-plan-dialog__status {
+  padding: 8px 12px;
+  border-radius: var(--radius-pill);
+  font-size: 13px;
+  background: var(--color-surface-alt);
+  color: var(--color-text-primary);
+}
+
+.invest-plan-dialog__status--success {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.invest-plan-dialog__status--error {
+  background: var(--color-negative-soft);
+  color: var(--color-negative);
+}
+
+.invest-plan-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.invest-plan-section__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.invest-plan-cash {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.invest-plan-cash__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.invest-plan-cash__label {
+  margin: 0;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.invest-plan-cash__value {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.invest-plan-purchases-wrapper {
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-card);
+  overflow: hidden;
+}
+
+.invest-plan-purchases {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.invest-plan-purchases thead {
+  background: var(--color-surface-alt);
+}
+
+.invest-plan-purchases th,
+.invest-plan-purchases td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-divider);
+  text-align: left;
+  vertical-align: top;
+}
+
+.invest-plan-purchases th {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-secondary);
+}
+
+.invest-plan-purchases td {
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.invest-plan-purchases tbody tr:last-child th,
+.invest-plan-purchases tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.invest-plan-symbol {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.invest-plan-symbol__ticker {
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+  color: var(--color-text-primary);
+}
+
+.invest-plan-symbol__name {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.invest-plan-copy-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-divider);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  font-weight: 500;
+  font-size: 13px;
+  cursor: pointer;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, transform 0.1s ease;
+}
+
+.invest-plan-copy-button:hover,
+.invest-plan-copy-button:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  outline: none;
+}
+
+.invest-plan-copy-button:active {
+  transform: scale(0.98);
+}
+
+.invest-plan-copy-button--disabled {
+  border-style: dashed;
+  color: var(--color-text-muted);
+  background: transparent;
+  cursor: default;
+}
+
+.invest-plan-copy-button--disabled:hover,
+.invest-plan-copy-button--disabled:focus-visible {
+  border-color: var(--color-divider);
+  color: var(--color-text-muted);
+  background: transparent;
+}
+
+.invest-plan-empty {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.invest-plan-conversions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.invest-plan-conversions__item {
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-card);
+  background: var(--color-surface-alt);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.invest-plan-conversion__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.invest-plan-conversion__direction {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.invest-plan-conversion__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.invest-plan-conversion__details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.invest-plan-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 24px 24px;
+  border-top: 1px solid var(--color-divider);
+  background: var(--color-surface);
+}
+
+.invest-plan-footer__button {
+  border: 1px solid var(--color-divider);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 18px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.invest-plan-footer__button:hover,
+.invest-plan-footer__button:focus-visible {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  outline: none;
+}
+
+.invest-plan-footer__button--primary {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #ffffff;
+}
+
+.invest-plan-footer__button--primary:hover,
+.invest-plan-footer__button--primary:focus-visible {
+  background: #2f7f31;
+  border-color: #2f7f31;
+  color: #ffffff;
+}
+
 .equity-card__heading {
   display: flex;
   flex-direction: column;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -770,12 +770,39 @@ textarea {
   vertical-align: top;
 }
 
+.invest-plan-purchases__checkbox-header {
+  width: 48px;
+  text-align: center;
+}
+
 .invest-plan-purchases th {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--color-text-secondary);
+}
+
+.invest-plan-purchases__checkbox-cell {
+  padding-left: 12px;
+  padding-right: 12px;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.invest-plan-purchases__checkbox {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.invest-plan-purchases__row {
+  transition: background-color 150ms ease, opacity 150ms ease;
+}
+
+.invest-plan-purchases__row--completed {
+  background: var(--color-surface-alt);
+  opacity: 0.6;
 }
 
 .invest-plan-purchases td {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -516,6 +516,8 @@ function findPositionDetails(positions, symbol) {
   return null;
 }
 
+const DLR_SHARE_VALUE_USD = 10;
+
 function buildInvestEvenlyPlan({ positions, balances, currencyRates, baseCurrency = 'CAD' }) {
   if (!Array.isArray(positions) || positions.length === 0) {
     return null;
@@ -719,7 +721,8 @@ function buildInvestEvenlyPlan({ positions, balances, currencyRates, baseCurrenc
 
   if (usdShortfall > 0.01) {
     const cadEquivalent = hasUsdRate ? usdShortfall * usdRate : null;
-    const dlrPrice = dlrToDetails?.price ?? (hasUsdRate ? usdRate : null);
+    const dlrPrice =
+      dlrToDetails?.price ?? (hasUsdRate ? usdRate * DLR_SHARE_VALUE_USD : null);
     let dlrShares = null;
     let dlrSpendCad = cadEquivalent;
 
@@ -755,7 +758,7 @@ function buildInvestEvenlyPlan({ positions, balances, currencyRates, baseCurrenc
 
   if (cadShortfall > 0.01) {
     const usdEquivalent = hasUsdRate ? cadShortfall / usdRate : null;
-    const dlrUPrice = dlrUDetails?.price ?? null;
+    const dlrUPrice = dlrUDetails?.price ?? DLR_SHARE_VALUE_USD;
     let dlrUShares = null;
     let dlrSpendUsd = usdEquivalent;
 

--- a/client/src/components/InvestEvenlyDialog.jsx
+++ b/client/src/components/InvestEvenlyDialog.jsx
@@ -1,0 +1,444 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { formatMoney, formatNumber } from '../utils/formatters';
+
+function formatCopyNumber(value, decimals = 2, { trimTrailingZeros = false } = {}) {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  const precision = Math.max(0, Math.min(6, decimals));
+  const normalized = Number(value);
+  if (!Number.isFinite(normalized)) {
+    return null;
+  }
+  const fixed = normalized.toFixed(precision);
+  if (!trimTrailingZeros || precision === 0) {
+    return fixed;
+  }
+  return fixed.replace(/\.0+$/, '').replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
+}
+
+function formatCurrencyLabel(value, currency) {
+  if (!Number.isFinite(value)) {
+    return '—';
+  }
+  const code = currency || 'CAD';
+  return `${formatMoney(value)} ${code}`;
+}
+
+function formatWeight(weight) {
+  if (!Number.isFinite(weight)) {
+    return '—';
+  }
+  return `${formatNumber(weight * 100, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%`;
+}
+
+function formatShareDisplay(shares, precision) {
+  if (!Number.isFinite(shares) || shares <= 0) {
+    return '—';
+  }
+  const digits = Math.max(0, Number.isFinite(precision) ? precision : 0);
+  return formatNumber(shares, { minimumFractionDigits: digits, maximumFractionDigits: digits });
+}
+
+export default function InvestEvenlyDialog({ plan, onClose, copyToClipboard }) {
+  const [copyStatus, setCopyStatus] = useState(null);
+
+  useEffect(() => {
+    function handleKeyDown(event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!copyStatus) {
+      return undefined;
+    }
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+    const timer = window.setTimeout(() => {
+      setCopyStatus(null);
+    }, 2500);
+    return () => window.clearTimeout(timer);
+  }, [copyStatus]);
+
+  const handleOverlayClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  const copyValue = useCallback(
+    async (value, label) => {
+      if (!value || typeof copyToClipboard !== 'function') {
+        return;
+      }
+      try {
+        await copyToClipboard(value);
+        setCopyStatus({ message: `${label || 'Value'} copied to clipboard.`, tone: 'success' });
+      } catch (error) {
+        console.error('Failed to copy value', error);
+        setCopyStatus({ message: 'Unable to copy value. Copy manually if needed.', tone: 'error' });
+      }
+    },
+    [copyToClipboard]
+  );
+
+  const handleCopySummary = useCallback(() => {
+    if (!plan?.summaryText) {
+      return;
+    }
+    copyValue(plan.summaryText, 'Plan summary');
+  }, [plan?.summaryText, copyValue]);
+
+  const purchaseRows = useMemo(() => {
+    if (!plan?.purchases?.length) {
+      return [];
+    }
+    return plan.purchases.map((purchase) => {
+      const amountCopy = Number.isFinite(purchase.amount) && purchase.amount > 0
+        ? formatCopyNumber(purchase.amount, 2)
+        : null;
+      const shareCopy = Number.isFinite(purchase.shares) && purchase.shares > 0
+        ? formatCopyNumber(purchase.shares, purchase.sharePrecision ?? 0, { trimTrailingZeros: true })
+        : null;
+      const weightPercent = Number.isFinite(purchase.weight) ? purchase.weight : null;
+      return {
+        ...purchase,
+        amountCopy,
+        shareCopy,
+        weightPercent,
+      };
+    });
+  }, [plan?.purchases]);
+
+  const conversionRows = useMemo(() => {
+    if (!plan?.conversions?.length) {
+      return [];
+    }
+    return plan.conversions.map((conversion) => {
+      const spendCurrency = conversion.currency || (conversion.type === 'CAD_TO_USD' ? 'CAD' : 'USD');
+      const spendAmount = Number.isFinite(conversion.spendAmount)
+        ? conversion.spendAmount
+        : spendCurrency === 'CAD'
+        ? conversion.cadAmount
+        : conversion.usdAmount;
+      const amountCopy = Number.isFinite(spendAmount) && spendAmount > 0
+        ? formatCopyNumber(spendAmount, 2)
+        : null;
+      const shareCopy = Number.isFinite(conversion.shares) && conversion.shares > 0
+        ? formatCopyNumber(conversion.shares, conversion.sharePrecision ?? 0, { trimTrailingZeros: true })
+        : null;
+      return {
+        ...conversion,
+        spendCurrency,
+        spendAmount,
+        amountCopy,
+        shareCopy,
+      };
+    });
+  }, [plan?.conversions]);
+
+  const totals = plan?.totals || {};
+  const cash = plan?.cash || {};
+  const accountLabel = plan?.accountLabel || plan?.accountName || plan?.accountNumber || null;
+
+  return (
+    <div className="invest-plan-overlay" role="presentation" onClick={handleOverlayClick}>
+      <div
+        className="invest-plan-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="invest-plan-title"
+      >
+        <header className="invest-plan-dialog__header">
+          <div className="invest-plan-dialog__heading">
+            <h2 id="invest-plan-title" className="invest-plan-dialog__title">
+              Invest cash evenly
+            </h2>
+            {accountLabel && <p className="invest-plan-dialog__account">{accountLabel}</p>}
+            {plan?.accountUrl && (
+              <a
+                className="invest-plan-dialog__account-link"
+                href={plan.accountUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open account in Questrade
+              </a>
+            )}
+          </div>
+          <button type="button" className="invest-plan-dialog__close" onClick={onClose} aria-label="Close dialog">
+            ×
+          </button>
+        </header>
+
+        <div className="invest-plan-dialog__body">
+          {copyStatus && (
+            <div
+              className={`invest-plan-dialog__status invest-plan-dialog__status--${copyStatus.tone}`}
+              role="status"
+            >
+              {copyStatus.message}
+            </div>
+          )}
+
+          <section className="invest-plan-section">
+            <h3 className="invest-plan-section__title">Available cash</h3>
+            <dl className="invest-plan-cash">
+              <div className="invest-plan-cash__row">
+                <dt className="invest-plan-cash__label">CAD</dt>
+                <dd className="invest-plan-cash__value">{formatCurrencyLabel(cash.cad, 'CAD')}</dd>
+              </div>
+              <div className="invest-plan-cash__row">
+                <dt className="invest-plan-cash__label">USD</dt>
+                <dd className="invest-plan-cash__value">{formatCurrencyLabel(cash.usd, 'USD')}</dd>
+              </div>
+              <div className="invest-plan-cash__row">
+                <dt className="invest-plan-cash__label">Total (CAD)</dt>
+                <dd className="invest-plan-cash__value">{formatCurrencyLabel(cash.totalCad, plan?.baseCurrency || 'CAD')}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="invest-plan-section">
+            <h3 className="invest-plan-section__title">Planned purchases</h3>
+            {purchaseRows.length ? (
+              <div className="invest-plan-purchases-wrapper">
+                <table className="invest-plan-purchases">
+                  <thead>
+                    <tr>
+                      <th scope="col">Symbol</th>
+                      <th scope="col">Allocation</th>
+                      <th scope="col">Amount</th>
+                      <th scope="col">Shares</th>
+                      <th scope="col">Price</th>
+                      <th scope="col">Notes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {purchaseRows.map((purchase) => {
+                      const hasAmountCopy = Boolean(purchase.amountCopy);
+                      const hasShareCopy = Boolean(purchase.shareCopy);
+                      const priceLabel = Number.isFinite(purchase.price)
+                        ? `${formatMoney(purchase.price)} ${purchase.currency}`
+                        : '—';
+                      return (
+                        <tr key={purchase.symbol}>
+                          <th scope="row">
+                            <div className="invest-plan-symbol">
+                              <span className="invest-plan-symbol__ticker">{purchase.symbol}</span>
+                              {purchase.description && (
+                                <span className="invest-plan-symbol__name">{purchase.description}</span>
+                              )}
+                            </div>
+                          </th>
+                          <td>{formatWeight(purchase.weightPercent)}</td>
+                          <td>
+                            {hasAmountCopy ? (
+                              <button
+                                type="button"
+                                className="invest-plan-copy-button"
+                                onClick={() => copyValue(purchase.amountCopy, `${purchase.symbol} amount`)}
+                              >
+                                {formatCurrencyLabel(purchase.amount, purchase.currency)}
+                              </button>
+                            ) : (
+                              <span className="invest-plan-copy-button invest-plan-copy-button--disabled">
+                                {formatCurrencyLabel(purchase.amount, purchase.currency)}
+                              </span>
+                            )}
+                          </td>
+                          <td>
+                            {hasShareCopy ? (
+                              <button
+                                type="button"
+                                className="invest-plan-copy-button"
+                                onClick={() => copyValue(purchase.shareCopy, `${purchase.symbol} shares`)}
+                              >
+                                {formatShareDisplay(purchase.shares, purchase.sharePrecision)}
+                              </button>
+                            ) : (
+                              <span className="invest-plan-copy-button invest-plan-copy-button--disabled">
+                                {formatShareDisplay(purchase.shares, purchase.sharePrecision)}
+                              </span>
+                            )}
+                          </td>
+                          <td>{priceLabel}</td>
+                          <td>{purchase.note || '—'}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="invest-plan-empty">No eligible positions were found.</p>
+            )}
+          </section>
+
+          <section className="invest-plan-section">
+            <h3 className="invest-plan-section__title">Totals</h3>
+            <dl className="invest-plan-cash">
+              <div className="invest-plan-cash__row">
+                <dt className="invest-plan-cash__label">CAD purchases</dt>
+                <dd className="invest-plan-cash__value">{formatCurrencyLabel(totals.cadNeeded, 'CAD')}</dd>
+              </div>
+              <div className="invest-plan-cash__row">
+                <dt className="invest-plan-cash__label">USD purchases</dt>
+                <dd className="invest-plan-cash__value">{formatCurrencyLabel(totals.usdNeeded, 'USD')}</dd>
+              </div>
+              <div className="invest-plan-cash__row">
+                <dt className="invest-plan-cash__label">Remaining CAD</dt>
+                <dd className="invest-plan-cash__value">{formatCurrencyLabel(totals.cadRemaining, 'CAD')}</dd>
+              </div>
+              <div className="invest-plan-cash__row">
+                <dt className="invest-plan-cash__label">Remaining USD</dt>
+                <dd className="invest-plan-cash__value">{formatCurrencyLabel(totals.usdRemaining, 'USD')}</dd>
+              </div>
+            </dl>
+          </section>
+
+          {conversionRows.length > 0 && (
+            <section className="invest-plan-section">
+              <h3 className="invest-plan-section__title">FX conversions</h3>
+              <ul className="invest-plan-conversions">
+                {conversionRows.map((conversion) => {
+                  const amountLabel = formatCurrencyLabel(conversion.spendAmount, conversion.spendCurrency);
+                  const targetLabel = conversion.targetCurrency
+                    ? formatCurrencyLabel(
+                        conversion.targetCurrency === 'CAD' ? conversion.cadAmount : conversion.usdAmount,
+                        conversion.targetCurrency
+                      )
+                    : null;
+                  const directionLabel =
+                    conversion.type === 'CAD_TO_USD' ? 'Convert CAD → USD' : 'Convert USD → CAD';
+                  return (
+                    <li
+                      key={`${conversion.type}-${conversion.symbol}`}
+                      className="invest-plan-conversions__item"
+                    >
+                      <div className="invest-plan-conversion__header">
+                        <div className="invest-plan-symbol">
+                          <span className="invest-plan-symbol__ticker">{conversion.symbol}</span>
+                          {conversion.description && (
+                            <span className="invest-plan-symbol__name">{conversion.description}</span>
+                          )}
+                        </div>
+                        <span className="invest-plan-conversion__direction">{directionLabel}</span>
+                      </div>
+                      <div className="invest-plan-conversion__actions">
+                        {conversion.amountCopy ? (
+                          <button
+                            type="button"
+                            className="invest-plan-copy-button"
+                            onClick={() => copyValue(conversion.amountCopy, `${conversion.symbol} amount`)}
+                          >
+                            Spend {amountLabel}
+                          </button>
+                        ) : (
+                          <span className="invest-plan-copy-button invest-plan-copy-button--disabled">
+                            Spend {amountLabel}
+                          </span>
+                        )}
+                        {conversion.shareCopy && (
+                          <button
+                            type="button"
+                            className="invest-plan-copy-button"
+                            onClick={() => copyValue(conversion.shareCopy, `${conversion.symbol} shares`)}
+                          >
+                            Buy {formatShareDisplay(conversion.shares, conversion.sharePrecision)} shares
+                          </button>
+                        )}
+                      </div>
+                      <div className="invest-plan-conversion__details">
+                        {targetLabel && <span className="invest-plan-conversion__detail">Target: {targetLabel}</span>}
+                        {conversion.sharePrice && (
+                          <span className="invest-plan-conversion__detail">
+                            Price: {formatCurrencyLabel(conversion.sharePrice, conversion.spendCurrency)}
+                          </span>
+                        )}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          )}
+        </div>
+
+        <footer className="invest-plan-dialog__footer">
+          <button type="button" className="invest-plan-footer__button" onClick={handleCopySummary}>
+            Copy plan summary
+          </button>
+          <button type="button" className="invest-plan-footer__button invest-plan-footer__button--primary" onClick={onClose}>
+            Close
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+const purchaseShape = PropTypes.shape({
+  symbol: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  currency: PropTypes.string,
+  amount: PropTypes.number,
+  targetAmount: PropTypes.number,
+  shares: PropTypes.number,
+  sharePrecision: PropTypes.number,
+  price: PropTypes.number,
+  note: PropTypes.string,
+  weight: PropTypes.number,
+});
+
+const conversionShape = PropTypes.shape({
+  type: PropTypes.oneOf(['CAD_TO_USD', 'USD_TO_CAD']).isRequired,
+  symbol: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  cadAmount: PropTypes.number,
+  usdAmount: PropTypes.number,
+  sharePrice: PropTypes.number,
+  shares: PropTypes.number,
+  sharePrecision: PropTypes.number,
+  spendAmount: PropTypes.number,
+  currency: PropTypes.string,
+  targetCurrency: PropTypes.string,
+});
+
+InvestEvenlyDialog.propTypes = {
+  plan: PropTypes.shape({
+    summaryText: PropTypes.string,
+    baseCurrency: PropTypes.string,
+    cash: PropTypes.shape({
+      cad: PropTypes.number,
+      usd: PropTypes.number,
+      totalCad: PropTypes.number,
+    }),
+    purchases: PropTypes.arrayOf(purchaseShape),
+    totals: PropTypes.shape({
+      cadNeeded: PropTypes.number,
+      usdNeeded: PropTypes.number,
+      cadRemaining: PropTypes.number,
+      usdRemaining: PropTypes.number,
+    }),
+    conversions: PropTypes.arrayOf(conversionShape),
+    accountName: PropTypes.string,
+    accountNumber: PropTypes.string,
+    accountLabel: PropTypes.string,
+    accountUrl: PropTypes.string,
+  }).isRequired,
+  onClose: PropTypes.func.isRequired,
+  copyToClipboard: PropTypes.func,
+};
+
+InvestEvenlyDialog.defaultProps = {
+  copyToClipboard: null,
+};

--- a/client/src/components/InvestEvenlyDialog.jsx
+++ b/client/src/components/InvestEvenlyDialog.jsx
@@ -148,6 +148,11 @@ export default function InvestEvenlyDialog({ plan, onClose, copyToClipboard }) {
         : spendCurrency === 'CAD'
         ? conversion.cadAmount
         : conversion.usdAmount;
+      const targetAmount = Number.isFinite(conversion.actualReceiveAmount)
+        ? conversion.actualReceiveAmount
+        : conversion.targetCurrency === 'CAD'
+        ? conversion.cadAmount
+        : conversion.usdAmount;
       const amountCopy = Number.isFinite(spendAmount) && spendAmount > 0
         ? formatCopyNumber(spendAmount, 2)
         : null;
@@ -158,6 +163,7 @@ export default function InvestEvenlyDialog({ plan, onClose, copyToClipboard }) {
         ...conversion,
         spendCurrency,
         spendAmount,
+        targetAmount,
         amountCopy,
         shareCopy,
       };
@@ -232,12 +238,10 @@ export default function InvestEvenlyDialog({ plan, onClose, copyToClipboard }) {
               <ul className="invest-plan-conversions">
                 {conversionRows.map((conversion) => {
                   const amountLabel = formatCurrencyLabel(conversion.spendAmount, conversion.spendCurrency);
-                  const targetLabel = conversion.targetCurrency
-                    ? formatCurrencyLabel(
-                        conversion.targetCurrency === 'CAD' ? conversion.cadAmount : conversion.usdAmount,
-                        conversion.targetCurrency
-                      )
-                    : null;
+                  const targetLabel =
+                    conversion.targetCurrency && Number.isFinite(conversion.targetAmount)
+                      ? formatCurrencyLabel(conversion.targetAmount, conversion.targetCurrency)
+                      : null;
                   const directionLabel =
                     conversion.type === 'CAD_TO_USD' ? 'Convert CAD → USD' : 'Convert USD → CAD';
                   return (
@@ -436,6 +440,8 @@ const conversionShape = PropTypes.shape({
   shares: PropTypes.number,
   sharePrecision: PropTypes.number,
   spendAmount: PropTypes.number,
+  actualSpendAmount: PropTypes.number,
+  actualReceiveAmount: PropTypes.number,
   currency: PropTypes.string,
   targetCurrency: PropTypes.string,
 });

--- a/client/src/components/InvestEvenlyDialog.jsx
+++ b/client/src/components/InvestEvenlyDialog.jsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { formatMoney, formatNumber } from '../utils/formatters';
 
+const DESCRIPTION_CHAR_LIMIT = 21;
+
 function formatCopyNumber(value, decimals = 2, { trimTrailingZeros = false } = {}) {
   if (!Number.isFinite(value)) {
     return null;
@@ -39,6 +41,17 @@ function formatShareDisplay(shares, precision) {
   }
   const digits = Math.max(0, Number.isFinite(precision) ? precision : 0);
   return formatNumber(shares, { minimumFractionDigits: digits, maximumFractionDigits: digits });
+}
+
+function truncateDescription(value) {
+  if (!value) {
+    return null;
+  }
+  const normalized = String(value);
+  if (normalized.length <= DESCRIPTION_CHAR_LIMIT) {
+    return normalized;
+  }
+  return `${normalized.slice(0, DESCRIPTION_CHAR_LIMIT).trimEnd()}...`;
 }
 
 export default function InvestEvenlyDialog({ plan, onClose, copyToClipboard }) {
@@ -127,12 +140,14 @@ export default function InvestEvenlyDialog({ plan, onClose, copyToClipboard }) {
         ? formatCopyNumber(purchase.shares, purchase.sharePrecision ?? 0, { trimTrailingZeros: true })
         : null;
       const weightPercent = Number.isFinite(purchase.weight) ? purchase.weight : null;
+      const displayDescription = truncateDescription(purchase.description);
       return {
         ...purchase,
         amountCopy,
         shareCopy,
         weightPercent,
         rowKey,
+        displayDescription,
       };
     });
   }, [plan?.purchases]);
@@ -159,6 +174,7 @@ export default function InvestEvenlyDialog({ plan, onClose, copyToClipboard }) {
       const shareCopy = Number.isFinite(conversion.shares) && conversion.shares > 0
         ? formatCopyNumber(conversion.shares, conversion.sharePrecision ?? 0, { trimTrailingZeros: true })
         : null;
+      const displayDescription = truncateDescription(conversion.description);
       return {
         ...conversion,
         spendCurrency,
@@ -166,6 +182,7 @@ export default function InvestEvenlyDialog({ plan, onClose, copyToClipboard }) {
         targetAmount,
         amountCopy,
         shareCopy,
+        displayDescription,
       };
     });
   }, [plan?.conversions]);
@@ -252,8 +269,13 @@ export default function InvestEvenlyDialog({ plan, onClose, copyToClipboard }) {
                       <div className="invest-plan-conversion__header">
                         <div className="invest-plan-symbol">
                           <span className="invest-plan-symbol__ticker">{conversion.symbol}</span>
-                          {conversion.description && (
-                            <span className="invest-plan-symbol__name">{conversion.description}</span>
+                          {conversion.displayDescription && (
+                            <span
+                              className="invest-plan-symbol__name"
+                              title={conversion.description || undefined}
+                            >
+                              {conversion.displayDescription}
+                            </span>
                           )}
                         </div>
                         <span className="invest-plan-conversion__direction">{directionLabel}</span>
@@ -340,8 +362,13 @@ export default function InvestEvenlyDialog({ plan, onClose, copyToClipboard }) {
                           <th scope="row">
                             <div className="invest-plan-symbol">
                               <span className="invest-plan-symbol__ticker">{purchase.symbol}</span>
-                              {purchase.description && (
-                                <span className="invest-plan-symbol__name">{purchase.description}</span>
+                              {purchase.displayDescription && (
+                                <span
+                                  className="invest-plan-symbol__name"
+                                  title={purchase.description || undefined}
+                                >
+                                  {purchase.displayDescription}
+                                </span>
                               )}
                             </div>
                           </th>

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -67,7 +67,7 @@ MetricRow.defaultProps = {
   tooltip: null,
 };
 
-function ActionMenu({ onCopySummary, onEstimateCagr, disabled, chatUrl }) {
+function ActionMenu({ onCopySummary, onEstimateCagr, onPlanInvestEvenly, disabled, chatUrl }) {
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const containerRef = useRef(null);
@@ -76,6 +76,7 @@ function ActionMenu({ onCopySummary, onEstimateCagr, disabled, chatUrl }) {
   const hasChatLink = Boolean(normalizedChatUrl);
   const hasCopyAction = typeof onCopySummary === 'function';
   const hasEstimateAction = typeof onEstimateCagr === 'function';
+  const hasInvestEvenlyAction = typeof onPlanInvestEvenly === 'function';
 
   useEffect(() => {
     if (!open) {
@@ -146,6 +147,21 @@ function ActionMenu({ onCopySummary, onEstimateCagr, disabled, chatUrl }) {
     }
   };
 
+  const handlePlanInvestEvenly = async () => {
+    if (!onPlanInvestEvenly || disabled || busy) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await onPlanInvestEvenly();
+    } catch (error) {
+      console.error('Failed to prepare invest evenly plan', error);
+    } finally {
+      setBusy(false);
+      setOpen(false);
+    }
+  };
+
   const effectiveDisabled = disabled || busy;
   const menuId = generatedId || 'equity-card-action-menu';
 
@@ -192,6 +208,19 @@ function ActionMenu({ onCopySummary, onEstimateCagr, disabled, chatUrl }) {
               </button>
             </li>
           )}
+          {hasInvestEvenlyAction && (
+            <li role="none">
+              <button
+                type="button"
+                className="equity-card__action-menu-item"
+                role="menuitem"
+                onClick={handlePlanInvestEvenly}
+                disabled={busy}
+              >
+                Invest cash evenly
+              </button>
+            </li>
+          )}
           {hasEstimateAction && (
             <li role="none">
               <button
@@ -214,6 +243,7 @@ function ActionMenu({ onCopySummary, onEstimateCagr, disabled, chatUrl }) {
 ActionMenu.propTypes = {
   onCopySummary: PropTypes.func,
   onEstimateCagr: PropTypes.func,
+  onPlanInvestEvenly: PropTypes.func,
   disabled: PropTypes.bool,
   chatUrl: PropTypes.string,
 };
@@ -221,6 +251,7 @@ ActionMenu.propTypes = {
 ActionMenu.defaultProps = {
   onCopySummary: null,
   onEstimateCagr: null,
+  onPlanInvestEvenly: null,
   disabled: false,
   chatUrl: null,
 };
@@ -243,6 +274,7 @@ export default function SummaryMetrics({
   isAutoRefreshing,
   onCopySummary,
   onEstimateFutureCagr,
+  onPlanInvestEvenly,
   chatUrl,
   showQqqTemperature,
   qqqSummary,
@@ -377,10 +409,11 @@ export default function SummaryMetrics({
               People
             </button>
           )}
-          {(onCopySummary || onEstimateFutureCagr || chatUrl) && (
+          {(onCopySummary || onEstimateFutureCagr || onPlanInvestEvenly || chatUrl) && (
             <ActionMenu
               onCopySummary={onCopySummary}
               onEstimateCagr={onEstimateFutureCagr}
+              onPlanInvestEvenly={onPlanInvestEvenly}
               chatUrl={chatUrl}
             />
           )}
@@ -498,6 +531,7 @@ SummaryMetrics.propTypes = {
   isAutoRefreshing: PropTypes.bool,
   onCopySummary: PropTypes.func,
   onEstimateFutureCagr: PropTypes.func,
+  onPlanInvestEvenly: PropTypes.func,
   chatUrl: PropTypes.string,
   showQqqTemperature: PropTypes.bool,
   qqqSummary: PropTypes.shape({
@@ -522,6 +556,7 @@ SummaryMetrics.defaultProps = {
   isAutoRefreshing: false,
   onCopySummary: null,
   onEstimateFutureCagr: null,
+  onPlanInvestEvenly: null,
   chatUrl: null,
   showQqqTemperature: false,
   qqqSummary: null,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1599,7 +1599,13 @@ const BALANCE_NUMERIC_FIELDS = [
   'totalCost',
   'realizedPnl',
   'unrealizedPnl',
+  'exchangeRate',
+  'fxRate',
+  'conversionRate',
+  'rate',
 ];
+
+const BALANCE_DIRECT_FIELDS = new Set(['exchangeRate', 'fxRate', 'conversionRate', 'rate']);
 
 const BALANCE_FIELD_ALIASES = {
   dayPnl: ['dayPnL'],
@@ -1647,8 +1653,12 @@ function accumulateBalance(target, source) {
   BALANCE_NUMERIC_FIELDS.forEach(function (field) {
     const value = pickNumericValue(source, field);
     if (value !== null) {
-      const current = typeof target[field] === 'number' && Number.isFinite(target[field]) ? target[field] : 0;
-      target[field] = current + value;
+      if (BALANCE_DIRECT_FIELDS.has(field)) {
+        target[field] = value;
+      } else {
+        const current = typeof target[field] === 'number' && Number.isFinite(target[field]) ? target[field] : 0;
+        target[field] = current + value;
+      }
       markBalanceFieldPresent(target, field);
     }
   });


### PR DESCRIPTION
## Summary
- add portfolio balance helpers and an invest-evenly planner that allocates CAD/USD cash based on position weights
- hook the planner into the summary actions so the generated plan is copied to the clipboard via the new "Invest cash evenly" option

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e11445c490832db3f5cc4596dd5121