### PR TITLE
Add CAD toggle and journalling link to invest dialog

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -727,6 +727,14 @@ textarea {
   margin: 0;
 }
 
+.invest-plan-toggle-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .invest-plan-toggle-button {
   display: inline-flex;
   align-items: center;
@@ -752,6 +760,23 @@ textarea {
 
 .invest-plan-toggle-button:active {
   transform: scale(0.98);
+}
+
+.invest-plan-toggle-button--active {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: #ffffff;
+}
+
+.invest-plan-toggle-button--active:hover,
+.invest-plan-toggle-button--active:focus-visible {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: #ffffff;
+}
+
+.invest-plan-toggle-button--active:focus-visible {
+  box-shadow: 0 0 0 2px rgba(56, 155, 60, 0.3);
 }
 
 .invest-plan-toggle-note {


### PR DESCRIPTION
## Summary
- add a journalling shortcut and account number display to the FX conversions section of the invest evenly dialog
- allow rebuilding the plan without CAD purchases so USD cash is redistributed across USD positions
- style the dialog for the new controls and annotate the plan summary when CAD purchases are skipped

## Testing
- npm --prefix client run lint

------
https://chatgpt.com/codex/tasks/task_e_68e26f28c000832d99e2f445ad97eff8