### PR TITLE
Remove bold styling from journal link

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -970,7 +970,7 @@ textarea {
 
 .invest-plan-conversions__journal-link {
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 400;
   color: var(--color-accent);
   text-decoration: none;
 }


### PR DESCRIPTION
## Summary
- update the journal link in the FX conversions section to use normal font weight instead of bold

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27a822d3c832dbb3cc1e7964b4e9c