### PR TITLE
Allow overriding available cash in invest evenly dialog

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -814,6 +814,29 @@ textarea {
   font-weight: 500;
   color: var(--color-text-primary);
   font-variant-numeric: tabular-nums;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.invest-plan-cash__input {
+  width: 100%;
+  max-width: 160px;
+  padding: 6px 10px;
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-card);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  font-size: 15px;
+  font-weight: 500;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.invest-plan-cash__input:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px rgba(56, 155, 60, 0.25);
 }
 
 .invest-plan-purchases-wrapper {


### PR DESCRIPTION
## Summary
- add editable CAD and USD cash fields to the Invest Evenly dialog
- allow the plan builder to accept cash overrides and persist them when toggling options
- style the new cash inputs to match the dialog layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e27a6b68bc832d8a813896df463249