### PR TITLE
Increase width of Invest cash evenly dialog

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -605,7 +605,7 @@ textarea {
   border-radius: var(--radius-card);
   border: 1px solid var(--color-border);
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
-  width: min(960px, 100%);
+  width: min(1100px, 100%);
   max-height: 95vh;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- widen the Invest cash evenly dialog layout to reduce text wrapping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2ad86aeac832d94098b601cd29ddd