### PR TITLE
Add cash breakdown dialog for currency tabs

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -588,6 +588,175 @@ textarea {
   color: var(--color-text-secondary);
 }
 
+.cash-breakdown-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+}
+
+.cash-breakdown-dialog {
+  background: var(--color-surface);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
+  max-width: 440px;
+  width: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  overflow: hidden;
+}
+
+.cash-breakdown-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.cash-breakdown-dialog__heading h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.cash-breakdown-dialog__subtitle {
+  margin: 6px 0 0;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.cash-breakdown-dialog__hint {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.cash-breakdown-dialog__close {
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.cash-breakdown-dialog__close:hover,
+.cash-breakdown-dialog__close:focus-visible {
+  color: var(--color-text-primary);
+  background: var(--color-surface-alt);
+  outline: none;
+}
+
+.cash-breakdown-dialog__body {
+  margin-top: 20px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.cash-breakdown-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cash-breakdown-list__entry {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  padding: 12px 16px;
+  background: var(--color-surface);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.1s ease;
+  text-align: left;
+  color: inherit;
+}
+
+.cash-breakdown-list__entry:hover,
+.cash-breakdown-list__entry:focus-visible {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+  outline: none;
+}
+
+.cash-breakdown-list__entry:active {
+  transform: translateY(1px);
+}
+
+.cash-breakdown-list__info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cash-breakdown-list__name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.cash-breakdown-list__subtitle {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.cash-breakdown-list__values {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+
+.cash-breakdown-list__amount {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.cash-breakdown-list__percent {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.cash-breakdown-dialog__footer {
+  margin-top: 20px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.cash-breakdown-dialog__total-label {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.cash-breakdown-dialog__total-value {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
 .invest-plan-overlay {
   position: fixed;
   inset: 0;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -544,6 +544,16 @@ function resolveCashForCurrency(balances, currency) {
   return 0;
 }
 
+function normalizeAccountBalanceSummary(balances) {
+  if (!balances || typeof balances !== 'object') {
+    return null;
+  }
+  if (balances.combined || balances.perCurrency) {
+    return balances;
+  }
+  return { combined: balances };
+}
+
 function buildCashBreakdownForCurrency({ currency, accountIds, accountsById, accountBalances }) {
   const normalizedCurrency = typeof currency === 'string' ? currency.trim().toUpperCase() : '';
   if (!normalizedCurrency) {
@@ -570,12 +580,12 @@ function buildCashBreakdownForCurrency({ currency, accountIds, accountsById, acc
     }
 
     const account = accountsById.get(accountId);
-    const combinedBalances = accountBalances[accountId];
-    if (!combinedBalances || typeof combinedBalances !== 'object') {
+    const balanceSummary = normalizeAccountBalanceSummary(accountBalances[accountId]);
+    if (!balanceSummary) {
       return;
     }
 
-    const cashValue = resolveCashForCurrency({ combined: combinedBalances }, normalizedCurrency);
+    const cashValue = resolveCashForCurrency(balanceSummary, normalizedCurrency);
     if (!Number.isFinite(cashValue)) {
       return;
     }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import PnlHeatmapDialog from './components/PnlHeatmapDialog';
 import InvestEvenlyDialog from './components/InvestEvenlyDialog';
 import AnnualizedReturnDialog from './components/AnnualizedReturnDialog';
 import QqqTemperatureSection from './components/QqqTemperatureSection';
+import CashBreakdownDialog from './components/CashBreakdownDialog';
 import { formatMoney, formatNumber } from './utils/formatters';
 import { buildAccountSummaryUrl } from './utils/questrade';
 import './App.css';
@@ -409,6 +410,7 @@ function resolveDisplayTotalEquity(balances) {
 }
 
 const ZERO_PNL = Object.freeze({ dayPnl: 0, openPnl: 0, totalPnl: 0 });
+const MINIMUM_CASH_BREAKDOWN_AMOUNT = 5;
 
 function isFiniteNumber(value) {
   return typeof value === 'number' && Number.isFinite(value);
@@ -540,6 +542,117 @@ function resolveCashForCurrency(balances, currency) {
   }
 
   return 0;
+}
+
+function buildCashBreakdownForCurrency({ currency, accountIds, accountsById, accountBalances }) {
+  const normalizedCurrency = typeof currency === 'string' ? currency.trim().toUpperCase() : '';
+  if (!normalizedCurrency) {
+    return null;
+  }
+
+  if (!Array.isArray(accountIds) || accountIds.length === 0) {
+    return null;
+  }
+
+  if (!accountsById || typeof accountsById.get !== 'function') {
+    return null;
+  }
+
+  if (!accountBalances || typeof accountBalances !== 'object') {
+    return null;
+  }
+
+  const entries = [];
+
+  accountIds.forEach((accountId) => {
+    if (!accountId || !accountsById.has(accountId)) {
+      return;
+    }
+
+    const account = accountsById.get(accountId);
+    const combinedBalances = accountBalances[accountId];
+    if (!combinedBalances || typeof combinedBalances !== 'object') {
+      return;
+    }
+
+    const cashValue = resolveCashForCurrency({ combined: combinedBalances }, normalizedCurrency);
+    if (!Number.isFinite(cashValue)) {
+      return;
+    }
+
+    if (cashValue <= 0) {
+      return;
+    }
+
+    if (cashValue < MINIMUM_CASH_BREAKDOWN_AMOUNT - 0.01) {
+      return;
+    }
+
+    const displayName =
+      typeof account.displayName === 'string' && account.displayName.trim()
+        ? account.displayName.trim()
+        : '';
+    const ownerLabel =
+      typeof account.ownerLabel === 'string' && account.ownerLabel.trim()
+        ? account.ownerLabel.trim()
+        : '';
+    const accountNumber =
+      typeof account.number === 'string' && account.number.trim() ? account.number.trim() : '';
+
+    let primaryName = displayName;
+    if (!primaryName) {
+      if (ownerLabel && accountNumber) {
+        primaryName = `${ownerLabel} ${accountNumber}`;
+      } else {
+        primaryName = accountNumber || ownerLabel || accountId;
+      }
+    }
+
+    const subtitleParts = [];
+    if (ownerLabel && ownerLabel !== primaryName) {
+      subtitleParts.push(ownerLabel);
+    }
+    if (accountNumber && accountNumber !== primaryName) {
+      subtitleParts.push(accountNumber);
+    }
+    const uniqueSubtitleParts = Array.from(new Set(subtitleParts));
+    const subtitle = uniqueSubtitleParts.length ? uniqueSubtitleParts.join(' • ') : null;
+
+    entries.push({
+      accountId,
+      name: primaryName,
+      subtitle,
+      amount: cashValue,
+    });
+  });
+
+  if (!entries.length) {
+    return null;
+  }
+
+  const total = entries.reduce((sum, entry) => sum + entry.amount, 0);
+  if (!(total > 0)) {
+    return null;
+  }
+
+  const rankedEntries = entries
+    .map((entry) => ({
+      ...entry,
+      percent: (entry.amount / total) * 100,
+    }))
+    .sort((a, b) => {
+      const diff = b.amount - a.amount;
+      if (Math.abs(diff) > 0.01) {
+        return diff;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+  return {
+    currency: normalizedCurrency,
+    total,
+    entries: rankedEntries,
+  };
 }
 
 function findPositionDetails(positions, symbol) {
@@ -1563,6 +1676,7 @@ export default function App() {
   const [investEvenlyPlanInputs, setInvestEvenlyPlanInputs] = useState(null);
   const [pnlBreakdownMode, setPnlBreakdownMode] = useState(null);
   const [showReturnBreakdown, setShowReturnBreakdown] = useState(false);
+  const [cashBreakdownCurrency, setCashBreakdownCurrency] = useState(null);
   const [qqqData, setQqqData] = useState(null);
   const [qqqLoading, setQqqLoading] = useState(false);
   const [qqqError, setQqqError] = useState(null);
@@ -1570,10 +1684,25 @@ export default function App() {
   const { loading, data, error } = useSummaryData(activeAccountId, refreshKey);
 
   const accounts = useMemo(() => data?.accounts ?? [], [data?.accounts]);
+  const accountsById = useMemo(() => {
+    const map = new Map();
+    accounts.forEach((account) => {
+      if (account && typeof account.id === 'string' && account.id) {
+        map.set(account.id, account);
+      }
+    });
+    return map;
+  }, [accounts]);
   const filteredAccountIds = useMemo(
     () => (Array.isArray(data?.filteredAccountIds) ? data.filteredAccountIds : []),
     [data?.filteredAccountIds]
   );
+  const resolvedCashAccountIds = useMemo(() => {
+    if (filteredAccountIds.length) {
+      return filteredAccountIds.filter((accountId) => accountId && accountsById.has(accountId));
+    }
+    return Array.from(accountsById.keys());
+  }, [filteredAccountIds, accountsById]);
   const selectedAccount = useMemo(() => {
     if (activeAccountId === 'default') {
       if (filteredAccountIds.length === 1) {
@@ -2056,6 +2185,94 @@ export default function App() {
 
   const showingAllAccounts = selectedAccount === 'all';
 
+  const cashBreakdownData = useMemo(() => {
+    if (!cashBreakdownCurrency) {
+      return null;
+    }
+    return buildCashBreakdownForCurrency({
+      currency: cashBreakdownCurrency,
+      accountIds: resolvedCashAccountIds,
+      accountsById,
+      accountBalances: normalizedAccountBalances,
+    });
+  }, [
+    cashBreakdownCurrency,
+    resolvedCashAccountIds,
+    accountsById,
+    normalizedAccountBalances,
+  ]);
+
+  useEffect(() => {
+    if (!cashBreakdownCurrency) {
+      return;
+    }
+    if (!cashBreakdownData || !showingAllAccounts) {
+      setCashBreakdownCurrency(null);
+      return;
+    }
+    if (
+      !activeCurrency ||
+      activeCurrency.scope !== 'perCurrency' ||
+      activeCurrency.currency !== cashBreakdownCurrency
+    ) {
+      setCashBreakdownCurrency(null);
+    }
+  }, [
+    cashBreakdownCurrency,
+    cashBreakdownData,
+    showingAllAccounts,
+    activeCurrency,
+  ]);
+
+  const handleShowCashBreakdown = useCallback(
+    (currency) => {
+      if (!showingAllAccounts) {
+        return;
+      }
+      const normalizedCurrency = typeof currency === 'string' ? currency.trim().toUpperCase() : '';
+      if (!normalizedCurrency || (normalizedCurrency !== 'CAD' && normalizedCurrency !== 'USD')) {
+        return;
+      }
+      const breakdown = buildCashBreakdownForCurrency({
+        currency: normalizedCurrency,
+        accountIds: resolvedCashAccountIds,
+        accountsById,
+        accountBalances: normalizedAccountBalances,
+      });
+      if (!breakdown) {
+        return;
+      }
+      setCashBreakdownCurrency(normalizedCurrency);
+    },
+    [
+      showingAllAccounts,
+      resolvedCashAccountIds,
+      accountsById,
+      normalizedAccountBalances,
+    ]
+  );
+
+  const handleCloseCashBreakdown = useCallback(() => {
+    setCashBreakdownCurrency(null);
+  }, []);
+
+  const handleSelectAccountFromBreakdown = useCallback(
+    (accountId) => {
+      if (!accountId) {
+        return;
+      }
+      setCashBreakdownCurrency(null);
+      handleAccountChange(accountId);
+    },
+    [handleAccountChange]
+  );
+
+  const cashBreakdownAvailable =
+    showingAllAccounts &&
+    activeCurrency &&
+    activeCurrency.scope === 'perCurrency' &&
+    (activeCurrency.currency === 'CAD' || activeCurrency.currency === 'USD');
+
   const fetchQqqTemperature = useCallback(() => {
     if (qqqLoading) {
       return;
@@ -2495,6 +2712,11 @@ export default function App() {
             usdToCadRate={usdToCadRate}
             onShowPeople={handleOpenPeople}
             peopleDisabled={peopleDisabled}
+            onShowCashBreakdown={
+              cashBreakdownAvailable && activeCurrency
+                ? () => handleShowCashBreakdown(activeCurrency.currency)
+                : null
+            }
             onShowPnlBreakdown={orderedPositions.length ? handleShowPnlBreakdown : null}
             onShowAnnualizedReturn={handleShowAnnualizedReturnDetails}
             isRefreshing={isRefreshing}
@@ -2551,6 +2773,15 @@ export default function App() {
           isFilteredView={!showingAllAccounts}
           missingAccounts={peopleMissingAccounts}
           asOf={asOf}
+        />
+      )}
+      {cashBreakdownData && (
+        <CashBreakdownDialog
+          currency={cashBreakdownData.currency}
+          total={cashBreakdownData.total}
+          entries={cashBreakdownData.entries}
+          onClose={handleCloseCashBreakdown}
+          onSelectAccount={handleSelectAccountFromBreakdown}
         />
       )}
       {investEvenlyPlan && (

--- a/client/src/components/CashBreakdownDialog.jsx
+++ b/client/src/components/CashBreakdownDialog.jsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { formatMoney, formatNumber } from '../utils/formatters';
+
+const MINIMUM_DISPLAY_AMOUNT = 5;
+
+export default function CashBreakdownDialog({ currency, total, entries, onClose, onSelectAccount }) {
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const handleOverlayClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  const percentOptions = useMemo(
+    () => ({ minimumFractionDigits: 1, maximumFractionDigits: 1 }),
+    []
+  );
+
+  const normalizedCurrency = typeof currency === 'string' ? currency.trim().toUpperCase() : '';
+
+  const sortedEntries = useMemo(() => {
+    if (!Array.isArray(entries)) {
+      return [];
+    }
+    return entries.slice();
+  }, [entries]);
+
+  const handleAccountClick = (accountId) => {
+    if (!onSelectAccount) {
+      return;
+    }
+    onSelectAccount(accountId);
+  };
+
+  return (
+    <div className="cash-breakdown-overlay" role="presentation" onClick={handleOverlayClick}>
+      <div
+        className="cash-breakdown-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cash-breakdown-title"
+      >
+        <header className="cash-breakdown-dialog__header">
+          <div className="cash-breakdown-dialog__heading">
+            <h2 id="cash-breakdown-title">Cash in {normalizedCurrency}</h2>
+            <p className="cash-breakdown-dialog__subtitle">
+              Showing accounts with at least {formatMoney(MINIMUM_DISPLAY_AMOUNT)} in {normalizedCurrency}.
+            </p>
+            <p className="cash-breakdown-dialog__hint">Click an account to open it.</p>
+          </div>
+          <button
+            type="button"
+            className="cash-breakdown-dialog__close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="cash-breakdown-dialog__body">
+          <ul className="cash-breakdown-list">
+            {sortedEntries.map((entry) => {
+              const percentLabel = `${formatNumber(entry.percent, percentOptions)}%`;
+              return (
+                <li key={entry.accountId} className="cash-breakdown-list__item">
+                  <button
+                    type="button"
+                    className="cash-breakdown-list__entry"
+                    onClick={() => handleAccountClick(entry.accountId)}
+                  >
+                    <div className="cash-breakdown-list__info">
+                      <span className="cash-breakdown-list__name">{entry.name}</span>
+                      {entry.subtitle && (
+                        <span className="cash-breakdown-list__subtitle">{entry.subtitle}</span>
+                      )}
+                    </div>
+                    <div className="cash-breakdown-list__values">
+                      <span className="cash-breakdown-list__amount">{formatMoney(entry.amount)}</span>
+                      <span className="cash-breakdown-list__percent">{percentLabel}</span>
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        <footer className="cash-breakdown-dialog__footer">
+          <span className="cash-breakdown-dialog__total-label">Total cash</span>
+          <span className="cash-breakdown-dialog__total-value">{formatMoney(total)}</span>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+const entryShape = PropTypes.shape({
+  accountId: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
+  amount: PropTypes.number.isRequired,
+  percent: PropTypes.number.isRequired,
+});
+
+CashBreakdownDialog.propTypes = {
+  currency: PropTypes.string.isRequired,
+  total: PropTypes.number.isRequired,
+  entries: PropTypes.arrayOf(entryShape).isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSelectAccount: PropTypes.func,
+};
+
+CashBreakdownDialog.defaultProps = {
+  onSelectAccount: null,
+};

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -269,6 +269,7 @@ export default function SummaryMetrics({
   usdToCadRate,
   onShowPeople,
   peopleDisabled,
+  onShowCashBreakdown,
   onShowPnlBreakdown,
   onShowAnnualizedReturn,
   isRefreshing,
@@ -484,7 +485,12 @@ export default function SummaryMetrics({
         <dl className="equity-card__metric-column">
           <MetricRow label="Total equity" value={formatMoney(totalEquity)} tone="neutral" />
           <MetricRow label="Market value" value={formatMoney(marketValue)} tone="neutral" />
-          <MetricRow label="Cash" value={formatMoney(cash)} tone="neutral" />
+          <MetricRow
+            label="Cash"
+            value={formatMoney(cash)}
+            tone="neutral"
+            onActivate={onShowCashBreakdown || null}
+          />
           <MetricRow label="Buying power" value={formatMoney(buyingPower)} tone="neutral" />
         </dl>
       </div>
@@ -544,6 +550,7 @@ SummaryMetrics.propTypes = {
   usdToCadRate: PropTypes.number,
   onShowPeople: PropTypes.func,
   peopleDisabled: PropTypes.bool,
+  onShowCashBreakdown: PropTypes.func,
   onShowPnlBreakdown: PropTypes.func,
   onShowAnnualizedReturn: PropTypes.func,
   isRefreshing: PropTypes.bool,
@@ -570,6 +577,7 @@ SummaryMetrics.defaultProps = {
   usdToCadRate: null,
   onShowPeople: null,
   peopleDisabled: false,
+  onShowCashBreakdown: null,
   onShowPnlBreakdown: null,
   onShowAnnualizedReturn: null,
   isRefreshing: false,


### PR DESCRIPTION
## Summary
- make the cash metric interactive on CAD/USD currency tabs for the all-accounts view and compute the per-account cash distribution
- add a CashBreakdownDialog component with styling so the distribution is shown with totals and navigation back to individual accounts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2b057b74c832d868b6356bfe76efd