### PR TITLE
Refactor symbol breakdown helpers into reusable module

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1774,6 +1774,10 @@ export default function App() {
     () => (accountFundingSource && typeof accountFundingSource === 'object' ? accountFundingSource : EMPTY_OBJECT),
     [accountFundingSource]
   );
+  const symbolBreakdown = useMemo(
+    () => (Array.isArray(data?.symbolBreakdown) ? data.symbolBreakdown : []),
+    [data?.symbolBreakdown]
+  );
   const accountBalances = data?.accountBalances ?? EMPTY_OBJECT;
   const selectedAccountFunding = useMemo(() => {
     if (selectedAccount === 'all') {
@@ -2810,6 +2814,7 @@ export default function App() {
           baseCurrency={baseCurrency}
           asOf={asOf}
           totalMarketValue={heatmapMarketValue}
+          symbolBreakdown={symbolBreakdown}
         />
       )}
     </div>

--- a/server/src/symbolBreakdown.js
+++ b/server/src/symbolBreakdown.js
@@ -1,0 +1,185 @@
+'use strict';
+
+const SYMBOL_ALIAS_MAP = new Map([
+  ['QQQM', 'QQQ'],
+  ['QQM', 'QQQ'],
+]);
+
+const FUNDING_TYPE_REGEX = /(deposit|withdraw|transfer|journal)/i;
+
+const DIVIDEND_SYMBOL_OVERRIDES = new Map([
+  ['N003056', 'NVDA'],
+  ['A033916', 'ASML'],
+  ['.ENB', 'ENB'],
+  ['A040553', 'GOOG'],
+  ['C074212', 'CI'],
+  ['D052167', 'GGLL'],
+  ['H079292', 'SGOV'],
+  ['H082968', 'QQQ'],
+  ['L415517', 'LLY'],
+  ['M415385', 'MSFT'],
+  ['PSA', 'PSA'],
+  ['S022496', 'SPDR'],
+  ['T002234', 'TSM'],
+]);
+
+const SYMBOL_INCOME_REGEX = /(dividend|distribution|dist|interest|return of capital|capital gain|reinvest)/i;
+const SYMBOL_TRADE_REGEX = /(trade|buy|sell|short|cover|exercise|assign|assignment|option)/i;
+
+function normalizeBreakdownSymbol(symbol) {
+  if (symbol === undefined || symbol === null) {
+    return null;
+  }
+  const raw = String(symbol).trim();
+  if (!raw) {
+    return null;
+  }
+  const upper = raw.toUpperCase();
+  if (DIVIDEND_SYMBOL_OVERRIDES.has(upper)) {
+    return DIVIDEND_SYMBOL_OVERRIDES.get(upper);
+  }
+  let normalized = upper;
+  if (normalized.startsWith('.')) {
+    normalized = normalized.slice(1);
+  }
+  const withoutSuffix = normalized.endsWith('.TO') ? normalized.slice(0, -3) : normalized;
+  const alias = SYMBOL_ALIAS_MAP.get(withoutSuffix) || SYMBOL_ALIAS_MAP.get(normalized);
+  return alias || withoutSuffix || normalized;
+}
+
+function resolveActivitySymbolForBreakdown(activity) {
+  if (!activity || typeof activity !== 'object') {
+    return null;
+  }
+  const primary = normalizeBreakdownSymbol(activity.symbol);
+  const fallback = normalizeBreakdownSymbol(activity.symbolId);
+  const symbol = primary || fallback;
+  if (!symbol) {
+    return null;
+  }
+  const descriptionCandidates = [activity.symbolDescription, activity.description];
+  let description = null;
+  for (const candidate of descriptionCandidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed) {
+        description = trimmed;
+        break;
+      }
+    }
+  }
+  const symbolId =
+    activity.symbolId !== undefined && activity.symbolId !== null
+      ? String(activity.symbolId)
+      : null;
+  return {
+    symbol,
+    symbolId,
+    description,
+  };
+}
+
+function classifyActivityForSymbolBreakdown(activity) {
+  if (!activity || typeof activity !== 'object') {
+    return null;
+  }
+  if (isFundingActivity(activity)) {
+    return null;
+  }
+  const type = typeof activity.type === 'string' ? activity.type.toLowerCase() : '';
+  const action = typeof activity.action === 'string' ? activity.action.toLowerCase() : '';
+  const description = typeof activity.description === 'string' ? activity.description.toLowerCase() : '';
+  const combined = `${type} ${action}`;
+  if (SYMBOL_INCOME_REGEX.test(combined) || SYMBOL_INCOME_REGEX.test(description)) {
+    return 'income';
+  }
+  if (SYMBOL_TRADE_REGEX.test(combined) || SYMBOL_TRADE_REGEX.test(description)) {
+    return 'trade';
+  }
+  return null;
+}
+
+function accumulateSymbolBreakdown(target, entries) {
+  if (!(target instanceof Map) || !Array.isArray(entries)) {
+    return;
+  }
+  entries.forEach((entry) => {
+    if (!entry || typeof entry !== 'object') {
+      return;
+    }
+    const symbol = typeof entry.symbol === 'string' ? entry.symbol : null;
+    if (!symbol) {
+      return;
+    }
+    const key = symbol.toUpperCase();
+    if (!target.has(key)) {
+      target.set(key, {
+        symbol,
+        symbolId: entry.symbolId || null,
+        description: entry.description || null,
+        netCashFlowCad: 0,
+        incomeCad: 0,
+        tradeCad: 0,
+        investedCad: 0,
+        activityCount: 0,
+      });
+    }
+    const bucket = target.get(key);
+    bucket.netCashFlowCad += Number(entry.netCashFlowCad) || 0;
+    bucket.incomeCad += Number(entry.incomeCad) || 0;
+    bucket.tradeCad += Number(entry.tradeCad) || 0;
+    bucket.investedCad += Number(entry.investedCad) || 0;
+    bucket.activityCount += Number(entry.activityCount) || 0;
+    if (!bucket.description && entry.description) {
+      bucket.description = entry.description;
+    }
+    if (!bucket.symbolId && entry.symbolId) {
+      bucket.symbolId = entry.symbolId;
+    }
+  });
+}
+
+function finalizeSymbolBreakdown(map) {
+  if (!(map instanceof Map)) {
+    return [];
+  }
+  return Array.from(map.values())
+    .filter((entry) => {
+      const net = Number(entry.netCashFlowCad) || 0;
+      const income = Number(entry.incomeCad) || 0;
+      const invested = Number(entry.investedCad) || 0;
+      return (
+        entry.activityCount > 0 &&
+        (Math.abs(net) >= 0.01 || Math.abs(income) >= 0.01 || invested >= 0.01)
+      );
+    })
+    .sort((a, b) => Math.abs(b.netCashFlowCad) - Math.abs(a.netCashFlowCad));
+}
+
+function isFundingActivity(activity) {
+  if (!activity || typeof activity !== 'object') {
+    return false;
+  }
+  const type = typeof activity.type === 'string' ? activity.type : '';
+  const action = typeof activity.action === 'string' ? activity.action : '';
+  const description = typeof activity.description === 'string' ? activity.description : '';
+  return (
+    FUNDING_TYPE_REGEX.test(type) ||
+    FUNDING_TYPE_REGEX.test(action) ||
+    FUNDING_TYPE_REGEX.test(description)
+  );
+}
+
+module.exports = {
+  DIVIDEND_SYMBOL_OVERRIDES,
+  normalizeBreakdownSymbol,
+  resolveActivitySymbolForBreakdown,
+  classifyActivityForSymbolBreakdown,
+  accumulateSymbolBreakdown,
+  finalizeSymbolBreakdown,
+  SYMBOL_ALIAS_MAP,
+  FUNDING_TYPE_REGEX,
+  SYMBOL_INCOME_REGEX,
+  SYMBOL_TRADE_REGEX,
+  isFundingActivity,
+};

--- a/server/test/symbolBreakdown.test.js
+++ b/server/test/symbolBreakdown.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DIVIDEND_SYMBOL_OVERRIDES,
+  normalizeBreakdownSymbol,
+  resolveActivitySymbolForBreakdown,
+  classifyActivityForSymbolBreakdown,
+  accumulateSymbolBreakdown,
+  finalizeSymbolBreakdown,
+} = require('../src/symbolBreakdown');
+
+test('normalizeBreakdownSymbol applies overrides, aliases, and normalization', () => {
+  assert.equal(normalizeBreakdownSymbol('N003056'), 'NVDA');
+  assert.equal(normalizeBreakdownSymbol('.ENB'), 'ENB');
+  assert.equal(normalizeBreakdownSymbol('enb.to'), 'ENB');
+  assert.equal(normalizeBreakdownSymbol('qqqm'), 'QQQ');
+  assert.equal(normalizeBreakdownSymbol('  '), null);
+  assert.equal(normalizeBreakdownSymbol(null), null);
+});
+
+test('DIVIDEND_SYMBOL_OVERRIDES captures known Questrade dividend aliases', () => {
+  const expected = new Map([
+    ['N003056', 'NVDA'],
+    ['A033916', 'ASML'],
+    ['H082968', 'QQQ'],
+  ]);
+  for (const [alias, symbol] of expected.entries()) {
+    assert.equal(DIVIDEND_SYMBOL_OVERRIDES.get(alias), symbol);
+  }
+});
+
+test('resolveActivitySymbolForBreakdown prefers explicit symbol data and trims descriptions', () => {
+  const activity = {
+    symbol: 'n003056',
+    symbolId: 12345,
+    symbolDescription: '  Nvidia Corp ',
+    description: ' Dividend '
+  };
+  const resolved = resolveActivitySymbolForBreakdown(activity);
+  assert.deepEqual(resolved, {
+    symbol: 'NVDA',
+    symbolId: '12345',
+    description: 'Nvidia Corp',
+  });
+
+  const fallback = resolveActivitySymbolForBreakdown({
+    symbol: '',
+    symbolId: 'QQQM',
+    description: 'Trailing description',
+  });
+  assert.deepEqual(fallback, {
+    symbol: 'QQQ',
+    symbolId: 'QQQM',
+    description: 'Trailing description',
+  });
+});
+
+test('classifyActivityForSymbolBreakdown distinguishes funding, income, and trades', () => {
+  const income = classifyActivityForSymbolBreakdown({ description: 'Dividend paid' });
+  assert.equal(income, 'income');
+
+  const trade = classifyActivityForSymbolBreakdown({ type: 'Trade', action: 'Buy' });
+  assert.equal(trade, 'trade');
+
+  const funding = classifyActivityForSymbolBreakdown({ type: 'Deposit' });
+  assert.equal(funding, null);
+
+  const unknown = classifyActivityForSymbolBreakdown({ description: 'Service fee' });
+  assert.equal(unknown, null);
+});
+
+test('accumulateSymbolBreakdown merges entries and finalize filters insignificant buckets', () => {
+  const map = new Map();
+  accumulateSymbolBreakdown(map, [
+    { symbol: 'NVDA', netCashFlowCad: 100, incomeCad: 80, tradeCad: 20, investedCad: 0, activityCount: 1 },
+    { symbol: 'nvda', netCashFlowCad: -40, incomeCad: 0, tradeCad: -40, investedCad: 40, activityCount: 1 },
+    { symbol: 'QQQM', netCashFlowCad: 0.005, incomeCad: 0, tradeCad: 0, investedCad: 0, activityCount: 1 },
+    { symbol: 'TSM', netCashFlowCad: 50, incomeCad: 50, tradeCad: 0, investedCad: 0, activityCount: 1 },
+    null,
+    {},
+  ]);
+
+  const results = finalizeSymbolBreakdown(map);
+  assert.equal(results.length, 2);
+  assert.deepEqual(results[0], {
+    symbol: 'NVDA',
+    symbolId: null,
+    description: null,
+    netCashFlowCad: 60,
+    incomeCad: 80,
+    tradeCad: -20,
+    investedCad: 40,
+    activityCount: 2,
+  });
+  assert.deepEqual(results[1], {
+    symbol: 'TSM',
+    symbolId: null,
+    description: null,
+    netCashFlowCad: 50,
+    incomeCad: 50,
+    tradeCad: 0,
+    investedCad: 0,
+    activityCount: 1,
+  });
+  assert.ok(results.every((entry) => entry.symbol !== 'QQQM'));
+});
+
+describe('finalizeSymbolBreakdown sorting behaviour', () => {
+  test('sorts by absolute net cash flow descending', () => {
+    const map = new Map();
+    accumulateSymbolBreakdown(map, [
+      { symbol: 'A', netCashFlowCad: -10, incomeCad: 0, tradeCad: -10, investedCad: 10, activityCount: 1 },
+      { symbol: 'B', netCashFlowCad: 200, incomeCad: 0, tradeCad: 200, investedCad: 0, activityCount: 1 },
+      { symbol: 'C', netCashFlowCad: -50, incomeCad: 0, tradeCad: -50, investedCad: 50, activityCount: 1 },
+    ]);
+    const results = finalizeSymbolBreakdown(map);
+    assert.deepEqual(
+      results.map((entry) => entry.symbol),
+      ['B', 'C', 'A']
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- extract the symbol breakdown normalization and aggregation helpers into a dedicated module for reuse and easier maintenance
- add unit tests covering symbol normalization, classification, and aggregation behaviors for the total P&L breakdown

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2cceb39e0832da46619c0f765f95f