### PR TITLE
Fix dividends panel separators and footer spacing

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -2302,7 +2302,13 @@ button.time-pill:hover .time-pill__icon {
 }
 
 .dividends-card--panel .dividends-card__table-wrapper {
-  padding: 0 24px 12px;
+  padding: 0 0 12px;
+}
+
+.dividends-card--panel .dividends-table thead th,
+.dividends-card--panel .dividends-table tbody td {
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
 .dividends-card--panel .dividends-card__empty {
@@ -2440,6 +2446,10 @@ button.time-pill:hover .time-pill__icon {
   border-top: 1px solid var(--color-divider);
   font-size: 0.85rem;
   color: var(--color-text-secondary);
+}
+
+.dividends-card__footer--flush {
+  border-top: none;
 }
 
 .dividends-card__footer-label {

--- a/client/src/components/DividendBreakdown.jsx
+++ b/client/src/components/DividendBreakdown.jsx
@@ -92,6 +92,7 @@ function DividendBreakdown({ summary, variant }) {
 
   const variantClass = variant === 'panel' ? ' dividends-card--panel' : '';
   const entries = Array.isArray(summary.entries) ? summary.entries : [];
+  const hasEntries = entries.length > 0;
   const totalCad = Number.isFinite(summary.totalCad) ? summary.totalCad : null;
   const totalsByCurrencyLabel = formatCurrencyTotals(summary.totalsByCurrency);
   const rangeLabel = formatRange(summary.startDate, summary.endDate);
@@ -125,7 +126,7 @@ function DividendBreakdown({ summary, variant }) {
         </div>
       </header>
 
-      {entries.length > 0 ? (
+      {hasEntries ? (
         <div className="dividends-card__table-wrapper">
           <table className="dividends-table">
             <thead>
@@ -191,7 +192,9 @@ function DividendBreakdown({ summary, variant }) {
       )}
 
       {totalsByCurrencyLabel ? (
-        <footer className="dividends-card__footer">
+        <footer
+          className={`dividends-card__footer${hasEntries ? ' dividends-card__footer--flush' : ''}`}
+        >
           <span className="dividends-card__footer-label">Totals by currency:</span>
           <span className="dividends-card__footer-value">{totalsByCurrencyLabel}</span>
         </footer>


### PR DESCRIPTION
## Summary
- make the dividends panel table span the full pod width while keeping cell padding consistent
- drop the duplicate divider above the totals when entries are present

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3ae2adb10832dbbf09c000892620e