### PR TITLE
Add investment model dialog for QQQ summary

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -457,6 +457,59 @@ textarea {
   outline: none;
 }
 
+.qqq-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+}
+
+.qqq-dialog {
+  position: relative;
+  background: var(--color-surface);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
+  width: min(960px, 100%);
+  max-height: 90vh;
+  padding: 24px 24px 16px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.qqq-dialog__close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.qqq-dialog__close:hover,
+.qqq-dialog__close:focus-visible {
+  color: var(--color-text-primary);
+  background: var(--color-surface-alt);
+  outline: none;
+}
+
+.qqq-dialog__content {
+  margin-top: 24px;
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
 .beneficiaries-dialog__body {
   display: flex;
   flex-direction: column;
@@ -1303,6 +1356,30 @@ textarea {
 .equity-card__subtext-link:hover {
   color: inherit;
   text-decoration: none;
+}
+
+.equity-card__subtext-button {
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.equity-card__subtext-button:focus-visible {
+  outline: 2px solid #1b2733;
+  outline-offset: 2px;
+  border-radius: var(--radius-pill);
+}
+
+.equity-card__subtext-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .equity-card__subtext-label {

--- a/client/src/components/QqqTemperatureDialog.jsx
+++ b/client/src/components/QqqTemperatureDialog.jsx
@@ -1,0 +1,75 @@
+import { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import QqqTemperatureSection from './QqqTemperatureSection';
+
+export default function QqqTemperatureDialog({
+  onClose,
+  data,
+  loading,
+  error,
+  onRetry,
+  modelName,
+  lastRebalance,
+  evaluation,
+}) {
+  useEffect(() => {
+    function handleKeyDown(event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const handleOverlayClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="qqq-dialog-overlay" role="presentation" onClick={handleOverlayClick}>
+      <div className="qqq-dialog" role="dialog" aria-modal="true" aria-label="Investment model details">
+        <button type="button" className="qqq-dialog__close" onClick={onClose} aria-label="Close">
+          ×
+        </button>
+        <div className="qqq-dialog__content">
+          <QqqTemperatureSection
+            data={data}
+            loading={loading}
+            error={error}
+            onRetry={onRetry}
+            title="Investment Model"
+            modelName={modelName}
+            lastRebalance={lastRebalance}
+            evaluation={evaluation}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+QqqTemperatureDialog.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  data: QqqTemperatureSection.propTypes.data,
+  loading: PropTypes.bool,
+  error: PropTypes.instanceOf(Error),
+  onRetry: PropTypes.func,
+  modelName: PropTypes.string,
+  lastRebalance: PropTypes.string,
+  evaluation: QqqTemperatureSection.propTypes.evaluation,
+};
+
+QqqTemperatureDialog.defaultProps = {
+  data: QqqTemperatureSection.defaultProps.data,
+  loading: false,
+  error: null,
+  onRetry: null,
+  modelName: 'A1',
+  lastRebalance: null,
+  evaluation: QqqTemperatureSection.defaultProps.evaluation,
+};


### PR DESCRIPTION
## Summary
- make the QQQ temperature label clickable when viewing all accounts
- open a modal with the A1 investment model details using the existing temperature section
- style the dialog and new summary label button for accessibility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e426a7dadc832db792b02b21ce4313