### PR TITLE
Support multiple investment models per account

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A local web app that mirrors the Questrade web portal "Summary" tab so you can r
    - (Optional) Copy `server/account-beneficiaries.example.json` to `server/account-beneficiaries.json` and replace the placeholder account numbers with your own. The proxy reads this file to attach household beneficiary metadata (for example "Eli Bigham" or "Philanthropy") to each account.
    - (Optional) Copy `server/accounts.example.json` to `server/accounts.json` to define friendly account names, chat links, and Questrade portal UUIDs per account number. The proxy watches this file (or the path pointed to by `ACCOUNTS_FILE` / `ACCOUNT_NAMES_FILE`) for updates and forwards the resolved metadata to the UI so Ctrl/⌘-clicking the account selector can open the matching page in the Questrade portal. You can also:
      - Set `showQQQDetails` to surface the per-account QQQ temperature card.
-     - Attach an `investmentModel` key (plus `lastRebalance`) to evaluate a strategy with the optional bridge.
+     - Add an `investmentModels` array (each entry may include `model`, `symbol`, `leveragedSymbol`, `reserveSymbol`, and `lastRebalance`) to evaluate strategies with the optional bridge.
      - Provide `chatURL` links that appear under the summary card "Actions" menu.
      - Apply `netDepositAdjustment` and `cagrStartDate` overrides to tune funding / return calculations.
      - Mark `"default": true` on an account to have the dashboard start there after a restart.
@@ -49,7 +49,7 @@ A local web app that mirrors the Questrade web portal "Summary" tab so you can r
 
    Install Python dependencies for the bridge according to the helper repository's README. The server will also honour the
    `INVESTMENT_MODEL_REPO` environment variable if you prefer to keep the checkout elsewhere. The bridge is only required when
-   accounts are configured with an `investmentModel` or `showQQQDetails`.
+   accounts are configured with `investmentModels` or `showQQQDetails`.
 
 4. Run the backend
 

--- a/client/src/api/questrade.js
+++ b/client/src/api/questrade.js
@@ -15,6 +15,30 @@ function buildQqqTemperatureUrl() {
   return url.toString();
 }
 
+function buildInvestmentModelTemperatureUrl(params) {
+  const base = API_BASE_URL.replace(/\/$/, '');
+  const url = new URL('/api/investment-model-temperature', base);
+  if (params && typeof params.model === 'string' && params.model.trim()) {
+    url.searchParams.set('model', params.model.trim());
+  }
+  if (params && typeof params.startDate === 'string' && params.startDate.trim()) {
+    url.searchParams.set('startDate', params.startDate.trim());
+  }
+  if (params && typeof params.endDate === 'string' && params.endDate.trim()) {
+    url.searchParams.set('endDate', params.endDate.trim());
+  }
+  if (params && typeof params.symbol === 'string' && params.symbol.trim()) {
+    url.searchParams.set('symbol', params.symbol.trim());
+  }
+  if (params && typeof params.leveragedSymbol === 'string' && params.leveragedSymbol.trim()) {
+    url.searchParams.set('leveragedSymbol', params.leveragedSymbol.trim());
+  }
+  if (params && typeof params.reserveSymbol === 'string' && params.reserveSymbol.trim()) {
+    url.searchParams.set('reserveSymbol', params.reserveSymbol.trim());
+  }
+  return url.toString();
+}
+
 function buildQuoteUrl(symbol) {
   const base = API_BASE_URL.replace(/\/$/, '');
   const url = new URL('/api/quote', base);
@@ -39,6 +63,35 @@ export async function getQqqTemperature() {
     const text = await response.text();
     throw new Error(text || 'Failed to load QQQ temperature data');
   }
+  return response.json();
+}
+
+export async function getInvestmentModelTemperature(params) {
+  const model = params && typeof params.model === 'string' ? params.model.trim() : '';
+  if (!model) {
+    throw new Error('Model is required');
+  }
+
+  const response = await fetch(buildInvestmentModelTemperatureUrl({ ...params, model }));
+  if (!response.ok) {
+    let message = 'Failed to load investment model chart';
+    try {
+      const payload = await response.json();
+      message = payload?.message || payload?.details || message;
+    } catch (parseError) {
+      console.warn('Failed to parse investment model chart error response', parseError);
+      try {
+        const text = await response.text();
+        if (text && text.trim()) {
+          message = text.trim();
+        }
+      } catch (nestedError) {
+        console.warn('Failed to read investment model chart error response', nestedError);
+      }
+    }
+    throw new Error(message);
+  }
+
   return response.json();
 }
 

--- a/client/src/components/QqqTemperatureSection.jsx
+++ b/client/src/components/QqqTemperatureSection.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { formatDate, formatNumber, formatPercent } from '../utils/formatters';
 
@@ -173,7 +173,10 @@ export default function QqqTemperatureSection({
   const displayRangeStart = chartMetrics ? chartMetrics.rangeStart : data?.rangeStart;
   const displayRangeEnd = chartMetrics ? chartMetrics.rangeEnd : data?.rangeEnd;
   const resolvedTitle = title || (modelName ? 'Investment Model' : 'QQQ temperature');
-  const headingId = modelName ? 'investment-model-heading' : 'qqq-temperature-heading';
+  const generatedId = useId();
+  const headingId = modelName
+    ? `investment-model-heading-${generatedId}`
+    : `qqq-temperature-heading-${generatedId}`;
   const loadingLabel = modelName ? 'Loading investment model…' : 'Loading QQQ temperature…';
   const errorLabel = modelName ? 'Unable to load investment model details.' : 'Unable to load QQQ temperature details.';
 

--- a/server/accounts.example.json
+++ b/server/accounts.example.json
@@ -4,8 +4,15 @@
     "uuid": "ac4ea32e-3034-4232-056a-194d8395463c",
     "chatURL": "https://chat.openai.com/share/example",
     "showQQQDetails": true,
-    "investmentModel": "A1",
-    "lastRebalance": "2024-01-15",
+    "investmentModels": [
+      {
+        "model": "A1",
+        "symbol": "QQQ",
+        "leveragedSymbol": "TQQQ",
+        "reserveSymbol": "SGOV",
+        "lastRebalance": "2024-01-15"
+      }
+    ],
     "default": true
   },
   "53384040": {


### PR DESCRIPTION
## Summary
- add server normalization for investmentModels arrays, evaluate each configured model, and return per-model metadata
- update the client to surface multiple investment model sections with unique headings and evaluation lookups
- document the new accounts.json structure and refresh the example configuration

## Testing
- npm --prefix server test
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68e42a025968832dab596ac16b3976f3