### PR TITLE
Add models tab for investment models

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1801,6 +1801,24 @@ textarea {
   cursor: pointer;
 }
 
+.positions-card__tabs button.positions-card__tab--attention {
+  color: var(--color-accent);
+}
+
+.positions-card__tab-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.positions-card__tab-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-surface);
+}
+
 .positions-card__tabs button.active {
   color: var(--color-accent);
 }


### PR DESCRIPTION
## Summary
- normalize investment model data across accounts and compute prioritized sections for display
- replace the standalone pod with a Models tab that lists each account/model combination and highlights required rebalances
- style the models tab with an attention indicator when action is needed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e43c00ee60832db99081260becec11