### PR TITLE
Add investment model access from positions table

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1399,7 +1399,7 @@ textarea {
   border-radius: var(--radius-pill);
   border: 1px solid var(--color-border-strong);
   background: var(--color-surface-alt);
-  color: var(--color-text-secondary);
+  color: var(--color-text-primary);
   font-size: 13px;
   line-height: 1.2;
   cursor: default;
@@ -1419,7 +1419,7 @@ textarea {
   background-repeat: no-repeat;
   background-position: center;
   background-size: 14px 14px;
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M0%200h24v24H0Z%22%20fill%3D%22none%22%2F%3E%3Cpath%20d%3D%22M17.65%206.35A8%208%200%201%200%2019.73%2014h-2.08A6%206%200%201%201%2012%206a5.92%205.92%200%200%201%204.22%201.78L13%2011h7V4Z%22%20fill%3D%22%236b7787%22%2F%3E%3C%2Fsvg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M0%200h24v24H0Z%22%20fill%3D%22none%22%2F%3E%3Cpath%20d%3D%22M17.65%206.35A8%208%200%201%200%2019.73%2014h-2.08A6%206%200%201%201%2012%206a5.92%205.92%200%200%201%204.22%201.78L13%2011h7V4Z%22%20fill%3D%22%231b2733%22%2F%3E%3C%2Fsvg%3E");
 }
 
 .time-pill--auto {
@@ -1935,10 +1935,38 @@ textarea {
   gap: 4px;
 }
 
+.positions-table__symbol-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
 .positions-table__symbol-ticker {
   font-size: 15px;
   font-weight: 600;
   color: var(--color-text-primary);
+}
+
+.positions-table__model-link {
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.positions-table__model-link:hover {
+  text-decoration-thickness: 2px;
+}
+
+.positions-table__model-link:focus-visible {
+  outline: 2px solid var(--color-border-active);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .positions-table__symbol-name {
@@ -2092,7 +2120,7 @@ button.time-pill:hover .time-pill__icon {
   background-repeat: no-repeat;
   background-position: center;
   background-size: 14px 14px;
-  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M0%200h24v24H0Z%22%20fill%3D%22none%22%2F%3E%3Cpath%20d%3D%22M17.65%206.35A8%208%200%201%200%2019.73%2014h-2.08A6%206%200%201%201%2012%206a5.92%205.92%200%200%201%204.22%201.78L13%2011h7V4Z%22%20fill%3D%22%236b7787%22%2F%3E%3C%2Fsvg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M0%200h24v24H0Z%22%20fill%3D%22none%22%2F%3E%3Cpath%20d%3D%22M17.65%206.35A8%208%200%201%200%2019.73%2014h-2.08A6%206%200%201%201%2012%206a5.92%205.92%200%200%201%204.22%201.78L13%2011h7V4Z%22%20fill%3D%22%231b2733%22%2F%3E%3C%2Fsvg%3E");
 }
 .positions-table__cell--currency span {
   text-transform: uppercase;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1954,19 +1954,21 @@ textarea {
   background: none;
   font-size: 11px;
   font-weight: 500;
-  color: var(--color-accent);
-  text-decoration: underline;
+  color: var(--color-text-secondary);
+  text-decoration: none;
   cursor: pointer;
+  transition: color 120ms ease-in-out;
 }
 
 .positions-table__model-link:hover {
-  text-decoration-thickness: 2px;
+  color: var(--color-text-primary);
 }
 
 .positions-table__model-link:focus-visible {
   outline: 2px solid var(--color-border-active);
   outline-offset: 2px;
   border-radius: 2px;
+  color: var(--color-text-primary);
 }
 
 .positions-table__symbol-name {

--- a/client/src/components/PositionsTable.jsx
+++ b/client/src/components/PositionsTable.jsx
@@ -201,6 +201,8 @@ function PositionsTable({
   pnlMode: externalPnlMode,
   onPnlModeChange,
   embedded = false,
+  investmentModelSymbolMap = null,
+  onShowInvestmentModel = null,
 }) {
   const resolvedDirection = sortDirection === 'asc' ? 'asc' : 'desc';
   const initialExternalMode = externalPnlMode === 'percent' || externalPnlMode === 'currency'
@@ -403,6 +405,17 @@ function PositionsTable({
             position.symbolId ?? position.symbol ?? index
           }`;
           const rowKey = position.rowId || fallbackKey;
+          const normalizedSymbol =
+            typeof position.symbol === 'string' ? position.symbol.trim().toUpperCase() : '';
+          let modelSection = null;
+          if (normalizedSymbol && investmentModelSymbolMap) {
+            if (investmentModelSymbolMap instanceof Map) {
+              modelSection = investmentModelSymbolMap.get(normalizedSymbol) || null;
+            } else if (typeof investmentModelSymbolMap === 'object') {
+              modelSection = investmentModelSymbolMap[normalizedSymbol] || null;
+            }
+          }
+          const modelButtonLabel = modelSection?.displayTitle || modelSection?.title || modelSection?.model || 'Investment model';
 
           return (
             <div
@@ -412,7 +425,23 @@ function PositionsTable({
               onClick={(event) => handleRowNavigation(event, position.symbol)}
             >
               <div className="positions-table__cell positions-table__cell--symbol" role="cell">
-                <div className="positions-table__symbol-ticker">{position.symbol}</div>
+                <div className="positions-table__symbol-header">
+                  <div className="positions-table__symbol-ticker">{position.symbol}</div>
+                  {modelSection && typeof onShowInvestmentModel === 'function' ? (
+                    <button
+                      type="button"
+                      className="positions-table__model-link"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onShowInvestmentModel(modelSection);
+                      }}
+                      title={`View investment model guidance for ${modelButtonLabel}`}
+                      aria-label={`View investment model guidance for ${modelButtonLabel}`}
+                    >
+                      Model
+                    </button>
+                  ) : null}
+                </div>
                 <div className="positions-table__symbol-name" title={position.description || '\u2014'}>
                   {displayDescription}
                 </div>
@@ -505,6 +534,8 @@ PositionsTable.propTypes = {
   pnlMode: PropTypes.oneOf(['currency', 'percent']),
   onPnlModeChange: PropTypes.func,
   embedded: PropTypes.bool,
+  investmentModelSymbolMap: PropTypes.instanceOf(Map),
+  onShowInvestmentModel: PropTypes.func,
 };
 
 PositionsTable.defaultProps = {
@@ -515,6 +546,8 @@ PositionsTable.defaultProps = {
   pnlMode: null,
   onPnlModeChange: null,
   embedded: false,
+  investmentModelSymbolMap: null,
+  onShowInvestmentModel: null,
 };
 
 export default PositionsTable;

--- a/client/src/components/QqqTemperatureDialog.jsx
+++ b/client/src/components/QqqTemperatureDialog.jsx
@@ -11,6 +11,7 @@ export default function QqqTemperatureDialog({
   modelName,
   lastRebalance,
   evaluation,
+  title,
 }) {
   useEffect(() => {
     function handleKeyDown(event) {
@@ -42,7 +43,7 @@ export default function QqqTemperatureDialog({
             loading={loading}
             error={error}
             onRetry={onRetry}
-            title="Investment Model"
+            title={title}
             modelName={modelName}
             lastRebalance={lastRebalance}
             evaluation={evaluation}
@@ -62,6 +63,7 @@ QqqTemperatureDialog.propTypes = {
   modelName: PropTypes.string,
   lastRebalance: PropTypes.string,
   evaluation: QqqTemperatureSection.propTypes.evaluation,
+  title: PropTypes.string,
 };
 
 QqqTemperatureDialog.defaultProps = {
@@ -72,4 +74,5 @@ QqqTemperatureDialog.defaultProps = {
   modelName: 'A1',
   lastRebalance: null,
   evaluation: QqqTemperatureSection.defaultProps.evaluation,
+  title: 'Investment Model',
 };


### PR DESCRIPTION
## Summary
- add an investment model shortcut beside symbols in the positions table and open the matching model dialog
- update model dialog handling, tab order, and supporting logic to prefer the models tab before dividends for consistency
- switch the refresh pill styling to use the primary text/icon color so it matches other buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e454ae8260832da8962909a8fbf3b6