### PR TITLE
Add account selector to heatmap dialog

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1626,6 +1626,65 @@ textarea {
   backdrop-filter: blur(6px);
 }
 
+.pnl-heatmap-dialog__controls--select {
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  gap: 10px;
+}
+
+.pnl-heatmap-dialog__label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.pnl-heatmap-dialog__select-wrapper {
+  position: relative;
+}
+
+.pnl-heatmap-dialog__select {
+  appearance: none;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 999px;
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+  padding: 6px 34px 6px 14px;
+  min-width: 180px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pnl-heatmap-dialog__select:focus-visible {
+  outline: none;
+  border-color: rgba(148, 163, 184, 0.85);
+  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.25);
+}
+
+.pnl-heatmap-dialog__select[disabled] {
+  cursor: default;
+  color: var(--color-text-muted);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.pnl-heatmap-dialog__select-wrapper::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%);
+  pointer-events: none;
+  border-width: 5px 4px 0 4px;
+  border-style: solid;
+  border-color: var(--color-text-secondary) transparent transparent transparent;
+  opacity: 0.8;
+}
+
 .pnl-heatmap-dialog__control {
   appearance: none;
   border: none;
@@ -1756,6 +1815,20 @@ textarea {
     gap: 4px;
     padding: 3px;
     width: auto;
+  }
+
+  .pnl-heatmap-dialog__controls--select {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+  }
+
+  .pnl-heatmap-dialog__select-wrapper {
+    width: 100%;
+  }
+
+  .pnl-heatmap-dialog__select {
+    width: 100%;
   }
 
   .pnl-heatmap-board__symbol {

--- a/client/src/components/PnlHeatmapDialog.jsx
+++ b/client/src/components/PnlHeatmapDialog.jsx
@@ -686,8 +686,7 @@ export default function PnlHeatmapDialog({
     return totalMarketValue;
   }, [activeAccountOption, totalMarketValue]);
 
-  const hasAccountSelector = normalizedAccountOptions.length > 0;
-  const accountSelectDisabled = normalizedAccountOptions.length <= 1;
+  const hasAccountSelector = normalizedAccountOptions.length > 1;
 
   const nodes = useMemo(
     () => buildHeatmapNodes(activePositions, metricKey, styleMode),
@@ -791,7 +790,6 @@ export default function PnlHeatmapDialog({
                       className="pnl-heatmap-dialog__select"
                       value={accountSelection}
                       onChange={(event) => setAccountSelection(event.target.value)}
-                      disabled={accountSelectDisabled}
                     >
                       {normalizedAccountOptions.map((option) => (
                         <option key={option.value} value={option.value}>


### PR DESCRIPTION
## Summary
- compute per-account heatmap data and default selection in the app before opening the dialog
- add an account dropdown inside the P&L heatmap dialog that swaps the displayed positions and totals
- style the new selector so it fits into the heatmap dialog toolbar on desktop and mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e45609eb28832da3664d9ad090861a