### PR TITLE
Add benchmark return comparison to total P&L summary

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1552,27 +1552,26 @@ textarea {
   color: var(--color-text-muted);
 }
 
-.total-pnl-extra {
-  display: inline-flex;
+.equity-card__metric-row--total-with-details {
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.total-pnl-details {
+  align-self: stretch;
+  display: flex;
   flex-direction: column;
   align-items: flex-end;
   text-align: right;
   gap: 2px;
+  padding: 6px 0 12px;
+  border-bottom: 1px dotted var(--color-border-strong);
 }
 
-.total-pnl-extra__percent {
+.total-pnl-details__line {
   display: block;
-}
-
-.total-pnl-extra__details {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 2px;
-}
-
-.total-pnl-extra__line {
-  display: block;
+  font-size: 13px;
+  color: var(--color-text-muted);
 }
 
 .pnl-heatmap-overlay {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1552,6 +1552,29 @@ textarea {
   color: var(--color-text-muted);
 }
 
+.total-pnl-extra {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  text-align: right;
+  gap: 2px;
+}
+
+.total-pnl-extra__percent {
+  display: block;
+}
+
+.total-pnl-extra__details {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+.total-pnl-extra__line {
+  display: block;
+}
+
 .pnl-heatmap-overlay {
   position: fixed;
   inset: 0;

--- a/client/src/api/questrade.js
+++ b/client/src/api/questrade.js
@@ -39,6 +39,18 @@ function buildInvestmentModelTemperatureUrl(params) {
   return url.toString();
 }
 
+function buildBenchmarkReturnsUrl(params) {
+  const base = API_BASE_URL.replace(/\/$/, '');
+  const url = new URL('/api/benchmark-returns', base);
+  if (params && typeof params.startDate === 'string' && params.startDate.trim()) {
+    url.searchParams.set('startDate', params.startDate.trim());
+  }
+  if (params && typeof params.endDate === 'string' && params.endDate.trim()) {
+    url.searchParams.set('endDate', params.endDate.trim());
+  }
+  return url.toString();
+}
+
 function buildQuoteUrl(symbol) {
   const base = API_BASE_URL.replace(/\/$/, '');
   const url = new URL('/api/quote', base);
@@ -116,6 +128,36 @@ export async function getQuote(symbol) {
         }
       } catch (nestedError) {
         console.warn('Failed to read quote error response', nestedError);
+      }
+    }
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export async function getBenchmarkReturns(params) {
+  const startDate = params && typeof params.startDate === 'string' ? params.startDate.trim() : '';
+  if (!startDate) {
+    throw new Error('startDate is required');
+  }
+
+  const endDate = params && typeof params.endDate === 'string' ? params.endDate.trim() : '';
+  const response = await fetch(buildBenchmarkReturnsUrl({ startDate, endDate }));
+  if (!response.ok) {
+    let message = 'Failed to load benchmark returns';
+    try {
+      const payload = await response.json();
+      message = payload?.message || payload?.details || message;
+    } catch (parseError) {
+      console.warn('Failed to parse benchmark returns error response as JSON', parseError);
+      try {
+        const text = await response.text();
+        if (text && text.trim()) {
+          message = text.trim();
+        }
+      } catch (nestedError) {
+        console.warn('Failed to read benchmark returns error response', nestedError);
       }
     }
     throw new Error(message);

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -443,8 +443,14 @@ export default function SummaryMetrics({
           maximumFractionDigits: 2,
         })
       : '—';
-    const interestValue = Number.isFinite(interestRate?.averageRate)
-      ? formatPercent(interestRate.averageRate * 100, {
+    const hasPeriodReturn = Number.isFinite(interestRate?.periodReturn);
+    const interestBase = hasPeriodReturn
+      ? interestRate.periodReturn
+      : Number.isFinite(interestRate?.averageRate)
+        ? interestRate.averageRate
+        : null;
+    const interestValue = Number.isFinite(interestBase)
+      ? formatPercent(interestBase * 100, {
           minimumFractionDigits: 2,
           maximumFractionDigits: 2,
         })
@@ -452,7 +458,7 @@ export default function SummaryMetrics({
     detailLines = [
       `${qqqLabel}: ${qqqValue}`,
       `${spLabel}: ${spValue}`,
-      `Interest rate: ${interestValue}`,
+      `Interest: ${interestValue}`,
     ];
     const periodLabel = describePeriodLength(startDate, endDate);
     if (periodLabel) {
@@ -717,6 +723,8 @@ SummaryMetrics.propTypes = {
         startDate: PropTypes.string,
         endDate: PropTypes.string,
         averageRate: PropTypes.number,
+        periodReturn: PropTypes.number,
+        periodDays: PropTypes.number,
         dataPoints: PropTypes.number,
         source: PropTypes.string,
       }),

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -460,22 +460,17 @@ export default function SummaryMetrics({
     }
   }
 
-  const totalExtra = totalExtraPercent || detailLines.length
-    ? (
-        <span className="total-pnl-extra">
-          {totalExtraPercent ? <span className="total-pnl-extra__percent">{totalExtraPercent}</span> : null}
-          {detailLines.length > 0 ? (
-            <span className="total-pnl-extra__details">
-              {detailLines.map((line, index) => (
-                <span key={`total-extra-line-${index}`} className="total-pnl-extra__line">
-                  {line}
-                </span>
-              ))}
-            </span>
-          ) : null}
+  const hasDetailLines = detailLines.length > 0;
+
+  const totalDetailBlock = hasDetailLines ? (
+    <div className="total-pnl-details">
+      {detailLines.map((line, index) => (
+        <span key={`total-detail-line-${index}`} className="total-pnl-details__line">
+          {line}
         </span>
-      )
-    : null;
+      ))}
+    </div>
+  ) : null;
 
   return (
     <section className="equity-card">
@@ -590,9 +585,11 @@ export default function SummaryMetrics({
           <MetricRow
             label="Total P&L"
             value={formattedTotal}
-            extra={totalExtra}
+            extra={totalExtraPercent}
             tone={totalTone}
+            className={hasDetailLines ? 'equity-card__metric-row--total-with-details' : ''}
           />
+          {totalDetailBlock}
           <MetricRow
             label="Annualized return"
             tooltip="The equivalent constant yearly rate (with compounding) that gets from start value to today."

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -84,6 +84,14 @@ function ensureYahooFinanceClient() {
 const QUOTE_CACHE_TTL_SECONDS = 60;
 const quoteCache = new NodeCache({ stdTTL: QUOTE_CACHE_TTL_SECONDS, checkperiod: 120 });
 
+const BENCHMARK_CACHE_MAX_AGE_MS = 60 * 60 * 1000; // 1 hour
+const benchmarkReturnCache = new Map();
+
+const BENCHMARK_SYMBOLS = {
+  sp500: { symbol: '^GSPC', name: 'S&P 500' },
+  qqq: { symbol: 'QQQ', name: 'QQQ' },
+};
+
 function resolveLoginDisplay(login) {
   if (!login) {
     return null;
@@ -215,6 +223,130 @@ function normalizeDateOnly(value) {
     }
   }
   return null;
+}
+
+function getBenchmarkCacheKey(symbol, startDate, endDate) {
+  if (!symbol || !startDate || !endDate) {
+    return null;
+  }
+  return [symbol, startDate, endDate].join('|');
+}
+
+function getCachedBenchmarkReturn(cacheKey) {
+  if (!cacheKey) {
+    return { hit: false };
+  }
+  const entry = benchmarkReturnCache.get(cacheKey);
+  if (!entry) {
+    return { hit: false };
+  }
+  if (Date.now() - entry.cachedAt > BENCHMARK_CACHE_MAX_AGE_MS) {
+    benchmarkReturnCache.delete(cacheKey);
+    return { hit: false };
+  }
+  return { hit: true, value: entry.value };
+}
+
+function setCachedBenchmarkReturn(cacheKey, value) {
+  if (!cacheKey) {
+    return;
+  }
+  benchmarkReturnCache.set(cacheKey, { value, cachedAt: Date.now() });
+}
+
+async function computeBenchmarkReturn(symbol, startDate, endDate) {
+  if (!symbol || !startDate || !endDate) {
+    return null;
+  }
+
+  const cacheKey = getBenchmarkCacheKey(symbol, startDate, endDate);
+  if (cacheKey) {
+    const cached = getCachedBenchmarkReturn(cacheKey);
+    if (cached.hit) {
+      return cached.value;
+    }
+  }
+
+  const finance = ensureYahooFinanceClient();
+
+  const start = new Date(`${startDate}T00:00:00Z`);
+  const end = new Date(`${endDate}T00:00:00Z`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return null;
+  }
+
+  const exclusiveEnd = addDays(end, 1) || end;
+
+  const history = await finance.historical(symbol, {
+    period1: start,
+    period2: exclusiveEnd,
+    interval: '1d',
+  });
+
+  const normalized = Array.isArray(history)
+    ? history
+        .map((entry) => {
+          if (!entry || typeof entry !== 'object') {
+            return null;
+          }
+          const entryDate =
+            entry.date instanceof Date && !Number.isNaN(entry.date.getTime())
+              ? entry.date
+              : typeof entry.date === 'string'
+                ? new Date(entry.date)
+                : null;
+          if (!(entryDate instanceof Date) || Number.isNaN(entryDate.getTime())) {
+            return null;
+          }
+          const adjClose = Number(entry.adjClose);
+          const close = Number(entry.close);
+          const price = Number.isFinite(adjClose)
+            ? adjClose
+            : Number.isFinite(close)
+              ? close
+              : Number.NaN;
+          if (!Number.isFinite(price) || price <= 0) {
+            return null;
+          }
+          return { date: entryDate, price };
+        })
+        .filter(Boolean)
+        .sort((a, b) => a.date - b.date)
+    : [];
+
+  if (!normalized.length) {
+    if (cacheKey) {
+      setCachedBenchmarkReturn(cacheKey, null);
+    }
+    return null;
+  }
+
+  const first = normalized[0];
+  const last = normalized[normalized.length - 1];
+
+  if (!first || !last || !Number.isFinite(first.price) || !Number.isFinite(last.price) || first.price <= 0) {
+    if (cacheKey) {
+      setCachedBenchmarkReturn(cacheKey, null);
+    }
+    return null;
+  }
+
+  const growth = (last.price - first.price) / first.price;
+  const payload = {
+    symbol,
+    startDate: formatDateOnly(first.date),
+    endDate: formatDateOnly(last.date),
+    startPrice: first.price,
+    endPrice: last.price,
+    returnRate: Number.isFinite(growth) ? growth : null,
+    source: 'yahoo-finance2',
+  };
+
+  if (cacheKey) {
+    setCachedBenchmarkReturn(cacheKey, payload);
+  }
+
+  return payload;
 }
 
 function normalizeInvestmentModelConfig(raw) {
@@ -2391,6 +2523,33 @@ async function computeNetDepositsCore(account, perAccountCombinedBalances, optio
     annualizedReturn.startDate = appliedCagrStartDate.toISOString().slice(0, 10);
   }
 
+  let normalizedPeriodStart = null;
+  let normalizedPeriodEnd = formatDateOnly(now);
+  if (!normalizedPeriodEnd && typeof nowIsoString === 'string' && nowIsoString.trim()) {
+    normalizedPeriodEnd = nowIsoString.slice(0, 10);
+  }
+
+  if (Array.isArray(effectiveCashFlows)) {
+    for (const entry of effectiveCashFlows) {
+      const entryDate = parseCashFlowEntryDate(entry);
+      if (entryDate && (!normalizedPeriodStart || entryDate < new Date(`${normalizedPeriodStart}T00:00:00Z`))) {
+        normalizedPeriodStart = formatDateOnly(entryDate);
+      }
+    }
+  }
+
+  if (!normalizedPeriodStart && earliestFunding instanceof Date && !Number.isNaN(earliestFunding.getTime())) {
+    normalizedPeriodStart = formatDateOnly(earliestFunding);
+  }
+
+  if (normalizedPeriodStart && normalizedPeriodEnd) {
+    const startDateObj = new Date(`${normalizedPeriodStart}T00:00:00Z`);
+    const endDateObj = new Date(`${normalizedPeriodEnd}T00:00:00Z`);
+    if (Number.isNaN(startDateObj.getTime()) || Number.isNaN(endDateObj.getTime()) || startDateObj > endDateObj) {
+      normalizedPeriodStart = null;
+    }
+  }
+
   return {
     netDeposits: {
       perCurrency: perCurrencyObject,
@@ -2409,6 +2568,8 @@ async function computeNetDepositsCore(account, perAccountCombinedBalances, optio
             netDepositsCad: accountAdjustment,
           }
         : undefined,
+    periodStartDate: normalizedPeriodStart || undefined,
+    periodEndDate: normalizedPeriodEnd || undefined,
   };
 }
 
@@ -3291,6 +3452,62 @@ app.get('/api/quote', async function (req, res) {
   }
 });
 
+app.get('/api/benchmark-returns', async function (req, res) {
+  const rawStart = typeof req.query.startDate === 'string' ? req.query.startDate : '';
+  const rawEnd = typeof req.query.endDate === 'string' ? req.query.endDate : '';
+
+  const normalizedStart = normalizeDateOnly(rawStart);
+  if (!normalizedStart) {
+    return res.status(400).json({ message: 'Query parameter "startDate" is required' });
+  }
+
+  const todayIso = new Date().toISOString().slice(0, 10);
+  let normalizedEnd = normalizeDateOnly(rawEnd) || todayIso;
+  if (normalizedEnd > todayIso) {
+    normalizedEnd = todayIso;
+  }
+
+  const startDateObj = new Date(`${normalizedStart}T00:00:00Z`);
+  const endDateObj = new Date(`${normalizedEnd}T00:00:00Z`);
+  if (Number.isNaN(startDateObj.getTime()) || Number.isNaN(endDateObj.getTime())) {
+    return res.status(400).json({ message: 'Invalid date range specified' });
+  }
+  if (startDateObj > endDateObj) {
+    return res.status(400).json({ message: 'startDate must be on or before endDate' });
+  }
+
+  try {
+    const [sp500Return, qqqReturn] = await Promise.all([
+      computeBenchmarkReturn(BENCHMARK_SYMBOLS.sp500.symbol, normalizedStart, normalizedEnd),
+      computeBenchmarkReturn(BENCHMARK_SYMBOLS.qqq.symbol, normalizedStart, normalizedEnd),
+    ]);
+
+    return res.json({
+      startDate: normalizedStart,
+      endDate: normalizedEnd,
+      sp500: sp500Return
+        ? {
+            name: BENCHMARK_SYMBOLS.sp500.name,
+            ...sp500Return,
+          }
+        : null,
+      qqq: qqqReturn
+        ? {
+            name: BENCHMARK_SYMBOLS.qqq.name,
+            ...qqqReturn,
+          }
+        : null,
+    });
+  } catch (error) {
+    if (error && error.code === 'MISSING_DEPENDENCY') {
+      return res.status(503).json({ message: error.message });
+    }
+    const message = error && error.message ? error.message : 'Unknown error';
+    console.error('Failed to compute benchmark returns:', message);
+    return res.status(500).json({ message: 'Failed to compute benchmark returns', details: message });
+  }
+});
+
 app.get('/api/qqq-temperature', async function (req, res) {
   try {
     const summary = await getQqqTemperatureSummary();
@@ -3925,6 +4142,40 @@ app.get('/api/summary', async function (req, res) {
 
       if (aggregateTotals.cashFlowsCad.length > 0) {
         const aggregateAsOf = new Date().toISOString();
+        const aggregatePeriodEnd = aggregateAsOf.slice(0, 10);
+        let aggregatePeriodStartDate = null;
+        for (const entry of aggregateTotals.cashFlowsCad) {
+          const entryDate = parseCashFlowEntryDate(entry);
+          if (
+            entryDate &&
+            (!aggregatePeriodStartDate || entryDate < aggregatePeriodStartDate) &&
+            entryDate instanceof Date &&
+            !Number.isNaN(entryDate.getTime())
+          ) {
+            aggregatePeriodStartDate = entryDate;
+          }
+        }
+        let formattedAggregateStart = null;
+        if (aggregatePeriodStartDate) {
+          formattedAggregateStart = formatDateOnly(aggregatePeriodStartDate);
+        }
+        if (formattedAggregateStart && aggregatePeriodEnd) {
+          const startDateObj = new Date(`${formattedAggregateStart}T00:00:00Z`);
+          const endDateObj = new Date(`${aggregatePeriodEnd}T00:00:00Z`);
+          if (
+            Number.isNaN(startDateObj.getTime()) ||
+            Number.isNaN(endDateObj.getTime()) ||
+            startDateObj > endDateObj
+          ) {
+            formattedAggregateStart = null;
+          }
+        }
+        if (formattedAggregateStart) {
+          aggregateEntry.periodStartDate = formattedAggregateStart;
+        }
+        if (aggregatePeriodEnd) {
+          aggregateEntry.periodEndDate = aggregatePeriodEnd;
+        }
         let aggregateRate = null;
         if (!aggregateTotals.incomplete) {
           const computedRate = computeAccountAnnualizedReturn(aggregateTotals.cashFlowsCad, 'all');


### PR DESCRIPTION
## Summary
- compute benchmark periods and expose a benchmark returns API backed by Yahoo Finance data
- add benchmark period metadata to funding summaries so the client can request matching returns
- fetch benchmark returns in the UI and display S&P 500 and QQQ comparisons alongside Total P&L

## Testing
- `npm run lint` *(fails: npm not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e45f4452f8832daa91124ea890270d