### PR TITLE
Add TODO detection and summary card

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -117,6 +117,74 @@ textarea {
   color: var(--color-negative);
 }
 
+.todo-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.todo-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.todo-card__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.todo-card__count {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.todo-card__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.todo-card__item {
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: var(--color-neutral-soft);
+  border-left: 3px solid var(--color-border-active);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.todo-card__item--rebalance {
+  border-left-color: var(--color-negative);
+  background: var(--color-negative-soft);
+}
+
+.todo-card__item-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.todo-card__item-detail {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
 .account-selector {
   position: relative;
   min-width: 280px;
@@ -2147,6 +2215,14 @@ textarea {
   .equity-card,
   .positions-card {
     padding: 20px 20px 16px;
+  }
+
+  .todo-card {
+    padding: 18px 18px 16px;
+  }
+
+  .todo-card__item {
+    padding: 10px 12px;
   }
 
   .positions-card__models-panel {

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -67,7 +67,14 @@ MetricRow.defaultProps = {
   tooltip: null,
 };
 
-function ActionMenu({ onCopySummary, onEstimateCagr, onPlanInvestEvenly, disabled, chatUrl }) {
+function ActionMenu({
+  onCopySummary,
+  onEstimateCagr,
+  onPlanInvestEvenly,
+  onCheckTodos,
+  disabled,
+  chatUrl,
+}) {
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const containerRef = useRef(null);
@@ -77,6 +84,7 @@ function ActionMenu({ onCopySummary, onEstimateCagr, onPlanInvestEvenly, disable
   const hasCopyAction = typeof onCopySummary === 'function';
   const hasEstimateAction = typeof onEstimateCagr === 'function';
   const hasInvestEvenlyAction = typeof onPlanInvestEvenly === 'function';
+  const hasTodoCheckAction = typeof onCheckTodos === 'function';
 
   useEffect(() => {
     if (!open) {
@@ -162,6 +170,21 @@ function ActionMenu({ onCopySummary, onEstimateCagr, onPlanInvestEvenly, disable
     }
   };
 
+  const handleCheckTodos = async () => {
+    if (!onCheckTodos || disabled || busy) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await onCheckTodos();
+    } catch (error) {
+      console.error('Failed to check for TODOs', error);
+    } finally {
+      setBusy(false);
+      setOpen(false);
+    }
+  };
+
   const effectiveDisabled = disabled || busy;
   const menuId = generatedId || 'equity-card-action-menu';
 
@@ -193,6 +216,19 @@ function ActionMenu({ onCopySummary, onEstimateCagr, onPlanInvestEvenly, disable
               >
                 Chat
               </a>
+            </li>
+          )}
+          {hasTodoCheckAction && (
+            <li role="none">
+              <button
+                type="button"
+                className="equity-card__action-menu-item"
+                role="menuitem"
+                onClick={handleCheckTodos}
+                disabled={busy}
+              >
+                Check for TODOs
+              </button>
             </li>
           )}
           {hasCopyAction && (
@@ -244,6 +280,7 @@ ActionMenu.propTypes = {
   onCopySummary: PropTypes.func,
   onEstimateCagr: PropTypes.func,
   onPlanInvestEvenly: PropTypes.func,
+  onCheckTodos: PropTypes.func,
   disabled: PropTypes.bool,
   chatUrl: PropTypes.string,
 };
@@ -252,6 +289,7 @@ ActionMenu.defaultProps = {
   onCopySummary: null,
   onEstimateCagr: null,
   onPlanInvestEvenly: null,
+  onCheckTodos: null,
   disabled: false,
   chatUrl: null,
 };
@@ -277,6 +315,7 @@ export default function SummaryMetrics({
   onCopySummary,
   onEstimateFutureCagr,
   onPlanInvestEvenly,
+  onCheckTodos,
   chatUrl,
   showQqqTemperature,
   qqqSummary,
@@ -432,11 +471,16 @@ export default function SummaryMetrics({
               People
             </button>
           )}
-          {(onCopySummary || onEstimateFutureCagr || onPlanInvestEvenly || chatUrl) && (
+          {(onCopySummary ||
+            onEstimateFutureCagr ||
+            onPlanInvestEvenly ||
+            onCheckTodos ||
+            chatUrl) && (
             <ActionMenu
               onCopySummary={onCopySummary}
               onEstimateCagr={onEstimateFutureCagr}
               onPlanInvestEvenly={onPlanInvestEvenly}
+              onCheckTodos={onCheckTodos}
               chatUrl={chatUrl}
             />
           )}
@@ -575,6 +619,7 @@ SummaryMetrics.propTypes = {
   onCopySummary: PropTypes.func,
   onEstimateFutureCagr: PropTypes.func,
   onPlanInvestEvenly: PropTypes.func,
+  onCheckTodos: PropTypes.func,
   chatUrl: PropTypes.string,
   showQqqTemperature: PropTypes.bool,
   qqqSummary: PropTypes.shape({
@@ -603,6 +648,7 @@ SummaryMetrics.defaultProps = {
   onCopySummary: null,
   onEstimateFutureCagr: null,
   onPlanInvestEvenly: null,
+  onCheckTodos: null,
   chatUrl: null,
   showQqqTemperature: false,
   qqqSummary: null,

--- a/client/src/components/TodoSummary.jsx
+++ b/client/src/components/TodoSummary.jsx
@@ -1,0 +1,111 @@
+import { useId } from 'react';
+import PropTypes from 'prop-types';
+import { formatMoney } from '../utils/formatters';
+
+function resolveCurrencyLabel(currency) {
+  if (typeof currency !== 'string') {
+    return '';
+  }
+  const trimmed = currency.trim();
+  return trimmed ? trimmed.toUpperCase() : '';
+}
+
+export default function TodoSummary({ items }) {
+  const safeItems = Array.isArray(items) ? items.filter(Boolean) : [];
+  if (!safeItems.length) {
+    return null;
+  }
+
+  const headingId = useId();
+  const resolvedHeadingId = headingId || 'todo-card-title';
+  const accountIds = new Set();
+  safeItems.forEach((item) => {
+    if (item && item.accountId) {
+      accountIds.add(item.accountId);
+    }
+  });
+  const showAccountContext = accountIds.size > 1;
+
+  return (
+    <section className="todo-card" aria-labelledby={resolvedHeadingId}>
+      <header className="todo-card__header">
+        <h2 id={resolvedHeadingId} className="todo-card__title">
+          TODOs
+        </h2>
+        <span className="todo-card__count" aria-live="polite">
+          {safeItems.length === 1 ? '1 item' : `${safeItems.length} items`}
+        </span>
+      </header>
+      <ul className="todo-card__list">
+        {safeItems.map((item, index) => {
+          const key = item?.id || `${item?.type || 'todo'}-${item?.accountId || index}-${index}`;
+          const detailParts = [];
+          if (showAccountContext && item?.accountLabel) {
+            detailParts.push(item.accountLabel);
+          }
+          if (Array.isArray(item?.details)) {
+            item.details
+              .map((detail) => (typeof detail === 'string' ? detail.trim() : ''))
+              .filter(Boolean)
+              .forEach((detail) => detailParts.push(detail));
+          }
+          if (item?.type === 'rebalance' && item?.lastRebalance) {
+            detailParts.push(`Last rebalanced ${item.lastRebalance}`);
+          }
+
+          let titleText = 'Review portfolio';
+          if (item?.type === 'cash') {
+            const currency = resolveCurrencyLabel(item.currency);
+            const amountText = Number.isFinite(item?.amount)
+              ? formatMoney(item.amount)
+              : null;
+            if (currency && amountText) {
+              titleText = `Invest available ${currency} cash (${amountText} ${currency})`;
+            } else if (currency) {
+              titleText = `Invest available ${currency} cash`;
+            } else if (amountText) {
+              titleText = `Invest available cash (${amountText})`;
+            } else {
+              titleText = 'Invest available cash';
+            }
+          } else if (item?.type === 'rebalance') {
+            const modelLabel = item?.modelLabel || 'Investment model';
+            titleText = `Rebalance ${modelLabel}`;
+          } else if (typeof item?.title === 'string' && item.title.trim()) {
+            titleText = item.title.trim();
+          }
+
+          const detailText = detailParts.filter(Boolean).join(' • ');
+
+          return (
+            <li key={key} className={`todo-card__item todo-card__item--${item?.type || 'generic'}`}>
+              <span className="todo-card__item-title">{titleText}</span>
+              {detailText && <span className="todo-card__item-detail">{detailText}</span>}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+TodoSummary.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      type: PropTypes.string,
+      accountId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      accountLabel: PropTypes.string,
+      currency: PropTypes.string,
+      amount: PropTypes.number,
+      modelLabel: PropTypes.string,
+      lastRebalance: PropTypes.string,
+      title: PropTypes.string,
+      details: PropTypes.arrayOf(PropTypes.string),
+    })
+  ),
+};
+
+TodoSummary.defaultProps = {
+  items: [],
+};


### PR DESCRIPTION
## Summary
- add TODO analysis logic to compute rebalance and cash tasks for the active account selection
- surface TODO items with a new summary card and a "Check for TODOs" action menu entry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4653ac6b4832da829368f7d4dafc4