### PR TITLE
Add rebalance reminders and allow marking accounts as rebalanced

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -103,6 +103,87 @@ textarea {
   justify-content: flex-start;
 }
 
+.todo-panel {
+  margin: 0;
+  padding: 16px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.todo-panel__title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.todo-panel__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.todo-panel__item {
+  margin: 0;
+  padding: 0;
+}
+
+.todo-panel__button {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  background: var(--color-surface-alt);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: left;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.todo-panel__button:not(:disabled):hover {
+  border-color: var(--color-border-active);
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.1);
+  cursor: pointer;
+}
+
+.todo-panel__button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.todo-panel__button[data-status='overdue'] {
+  border-color: rgba(208, 75, 75, 0.4);
+  background: #fff7f7;
+}
+
+.todo-panel__primary {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--color-text-primary);
+}
+
+.todo-panel__meta {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.todo-panel__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
 .status-message {
   padding: 16px 20px;
   border-radius: var(--radius-card);

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -68,7 +68,14 @@ MetricRow.defaultProps = {
   tooltip: null,
 };
 
-function ActionMenu({ onCopySummary, onEstimateCagr, onPlanInvestEvenly, disabled, chatUrl }) {
+function ActionMenu({
+  onCopySummary,
+  onEstimateCagr,
+  onPlanInvestEvenly,
+  onMarkRebalanced,
+  disabled,
+  chatUrl,
+}) {
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const containerRef = useRef(null);
@@ -78,6 +85,7 @@ function ActionMenu({ onCopySummary, onEstimateCagr, onPlanInvestEvenly, disable
   const hasCopyAction = typeof onCopySummary === 'function';
   const hasEstimateAction = typeof onEstimateCagr === 'function';
   const hasInvestEvenlyAction = typeof onPlanInvestEvenly === 'function';
+  const hasMarkRebalancedAction = typeof onMarkRebalanced === 'function';
 
   useEffect(() => {
     if (!open) {
@@ -163,6 +171,21 @@ function ActionMenu({ onCopySummary, onEstimateCagr, onPlanInvestEvenly, disable
     }
   };
 
+  const handleMarkAsRebalanced = async () => {
+    if (!onMarkRebalanced || disabled || busy) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await onMarkRebalanced();
+    } catch (error) {
+      console.error('Failed to mark account as rebalanced', error);
+    } finally {
+      setBusy(false);
+      setOpen(false);
+    }
+  };
+
   const effectiveDisabled = disabled || busy;
   const menuId = generatedId || 'equity-card-action-menu';
 
@@ -209,6 +232,19 @@ function ActionMenu({ onCopySummary, onEstimateCagr, onPlanInvestEvenly, disable
               </button>
             </li>
           )}
+          {hasMarkRebalancedAction && (
+            <li role="none">
+              <button
+                type="button"
+                className="equity-card__action-menu-item"
+                role="menuitem"
+                onClick={handleMarkAsRebalanced}
+                disabled={busy}
+              >
+                Mark as rebalanced
+              </button>
+            </li>
+          )}
           {hasInvestEvenlyAction && (
             <li role="none">
               <button
@@ -245,6 +281,7 @@ ActionMenu.propTypes = {
   onCopySummary: PropTypes.func,
   onEstimateCagr: PropTypes.func,
   onPlanInvestEvenly: PropTypes.func,
+  onMarkRebalanced: PropTypes.func,
   disabled: PropTypes.bool,
   chatUrl: PropTypes.string,
 };
@@ -253,6 +290,7 @@ ActionMenu.defaultProps = {
   onCopySummary: null,
   onEstimateCagr: null,
   onPlanInvestEvenly: null,
+  onMarkRebalanced: null,
   disabled: false,
   chatUrl: null,
 };
@@ -277,6 +315,7 @@ export default function SummaryMetrics({
   isAutoRefreshing,
   onCopySummary,
   onEstimateFutureCagr,
+  onMarkRebalanced,
   onPlanInvestEvenly,
   chatUrl,
   showQqqTemperature,
@@ -536,11 +575,16 @@ export default function SummaryMetrics({
               People
             </button>
           )}
-          {(onCopySummary || onEstimateFutureCagr || onPlanInvestEvenly || chatUrl) && (
+          {(onCopySummary ||
+            onEstimateFutureCagr ||
+            onPlanInvestEvenly ||
+            onMarkRebalanced ||
+            chatUrl) && (
             <ActionMenu
               onCopySummary={onCopySummary}
               onEstimateCagr={onEstimateFutureCagr}
               onPlanInvestEvenly={onPlanInvestEvenly}
+              onMarkRebalanced={onMarkRebalanced}
               chatUrl={chatUrl}
             />
           )}
@@ -682,6 +726,7 @@ SummaryMetrics.propTypes = {
   isAutoRefreshing: PropTypes.bool,
   onCopySummary: PropTypes.func,
   onEstimateFutureCagr: PropTypes.func,
+  onMarkRebalanced: PropTypes.func,
   onPlanInvestEvenly: PropTypes.func,
   chatUrl: PropTypes.string,
   showQqqTemperature: PropTypes.bool,
@@ -749,6 +794,7 @@ SummaryMetrics.defaultProps = {
   isAutoRefreshing: false,
   onCopySummary: null,
   onEstimateFutureCagr: null,
+  onMarkRebalanced: null,
   onPlanInvestEvenly: null,
   chatUrl: null,
   showQqqTemperature: false,

--- a/server/accounts.example.json
+++ b/server/accounts.example.json
@@ -10,7 +10,8 @@
         "symbol": "QQQ",
         "leveragedSymbol": "TQQQ",
         "reserveSymbol": "SGOV",
-        "lastRebalance": "2024-01-15"
+        "lastRebalance": "2024-01-15",
+        "rebalancePeriod": 90
       }
     ],
     "default": true


### PR DESCRIPTION
## Summary
- expose rebalance period metadata and add an API route to mark accounts as rebalanced
- surface a TODO panel that highlights overdue rebalances and jumps to the account from the all-accounts view
- wire a "Mark as rebalanced" action into the summary metrics menu and update styling for the new reminders

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e473d2705c832dac5727d0ce6e328a