### PR TITLE
Use XIRR rate for total P&L percent

### DIFF
--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -395,13 +395,14 @@ export default function SummaryMetrics({
   const annualizedReturnRate = Number.isFinite(fundingSummary?.annualizedReturnRate)
     ? fundingSummary.annualizedReturnRate
     : null;
-  const formattedCagr =
+  const annualizedPercentDisplay =
     annualizedReturnRate === null
-      ? '—'
+      ? null
       : formatSignedPercent(annualizedReturnRate * 100, {
           minimumFractionDigits: 2,
           maximumFractionDigits: 2,
         });
+  const formattedCagr = annualizedPercentDisplay ?? '—';
   const cagrTone =
     annualizedReturnRate > 0 ? 'positive' : annualizedReturnRate < 0 ? 'negative' : 'neutral';
   const canShowReturnBreakdown =
@@ -492,7 +493,11 @@ export default function SummaryMetrics({
     return `${roundedMonths} month${roundedMonths === 1 ? '' : 's'}`;
   };
 
-  const totalExtraPercent = totalPercent ? `(${totalPercent})` : null;
+  const totalExtraPercent = annualizedPercentDisplay
+    ? `(${annualizedPercentDisplay})`
+    : totalPercent
+      ? `(${totalPercent})`
+      : null;
 
   let detailLines = [];
   if (benchmarkStatus === 'loading' || benchmarkStatus === 'refreshing') {


### PR DESCRIPTION
## Summary
- reuse the annualized return derived from the XIRR calculation when showing the Total P&L percent
- fall back to the previous percent calculation when an annualized rate is unavailable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4fa8c34c0832db7294e3af5c6de40