### PR TITLE
Avoid refreshing benchmark data on manual refresh

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3472,7 +3472,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [benchmarkPeriodStart, benchmarkPeriodEnd, refreshKey]);
+  }, [benchmarkPeriodStart, benchmarkPeriodEnd]);
   const displayTotalEquity = useMemo(() => {
     const canonical = resolveDisplayTotalEquity(balances);
     if (canonical !== null) {


### PR DESCRIPTION
## Summary
- remove the refresh key dependency from the benchmark returns effect so manual refreshes do not reload benchmarks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53da8eff8832d962ca55dc38bd673