### PR TITLE
Support ignoreSittingCash threshold for cash TODOs

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1266,6 +1266,12 @@ function buildTodoItems({ accountIds, accountsById, accountBalances, investmentM
     const balanceSummary = normalizeAccountBalanceSummary(
       accountBalances && typeof accountBalances === 'object' ? accountBalances[accountId] : null
     );
+    const ignoreSittingCashThreshold =
+      account &&
+      typeof account.ignoreSittingCash === 'number' &&
+      Number.isFinite(account.ignoreSittingCash)
+        ? Math.max(0, account.ignoreSittingCash)
+        : null;
     if (balanceSummary) {
       ['CAD', 'USD'].forEach((currency) => {
         const cashValue = resolveCashForCurrency(balanceSummary, currency);
@@ -1274,6 +1280,12 @@ function buildTodoItems({ accountIds, accountsById, accountBalances, investmentM
           cashValue > 0 &&
           cashValue >= TODO_CASH_THRESHOLD - TODO_AMOUNT_EPSILON
         ) {
+          const shouldIgnoreCashTodo =
+            ignoreSittingCashThreshold !== null &&
+            cashValue <= ignoreSittingCashThreshold + TODO_AMOUNT_EPSILON;
+          if (shouldIgnoreCashTodo) {
+            return;
+          }
           items.push({
             id: `cash:${accountId}:${currency}`,
             type: 'cash',

--- a/server/accounts.example.json
+++ b/server/accounts.example.json
@@ -14,7 +14,8 @@
         "rebalancePeriod": 90
       }
     ],
-    "default": true
+    "default": true,
+    "ignoreSittingCash": 250
   },
   "53384040": {
     "name": "Margin",

--- a/server/src/accountNames.js
+++ b/server/src/accountNames.js
@@ -328,6 +328,24 @@ function applyCagrStartDateSetting(target, key, value) {
   container.cagrStartDate = normalized;
 }
 
+function applyIgnoreSittingCashSetting(target, key, value) {
+  const container = ensureAccountSettingsEntry(target, key);
+  if (!container) {
+    return;
+  }
+  const normalized = normalizeNumberLike(value);
+  if (normalized === null) {
+    delete container.ignoreSittingCash;
+    return;
+  }
+  const rounded = Math.round(normalized);
+  if (!Number.isFinite(rounded) || rounded < 0) {
+    delete container.ignoreSittingCash;
+    return;
+  }
+  container.ignoreSittingCash = rounded;
+}
+
 function normalizeDateOnly(value) {
   if (value == null) {
     return null;
@@ -582,6 +600,9 @@ function extractEntry(
     }
     if (Object.prototype.hasOwnProperty.call(entry, 'cagrStartDate')) {
       applyCagrStartDateSetting(settingsTarget, resolvedKey, entry.cagrStartDate);
+    }
+    if (Object.prototype.hasOwnProperty.call(entry, 'ignoreSittingCash')) {
+      applyIgnoreSittingCashSetting(settingsTarget, resolvedKey, entry.ignoreSittingCash);
     }
   }
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -3950,6 +3950,12 @@ app.get('/api/summary', async function (req, res) {
                 normalizedAccount.cagrStartDate = trimmedDate;
               }
             }
+            if (
+              typeof accountSettingsOverride.ignoreSittingCash === 'number' &&
+              Number.isFinite(accountSettingsOverride.ignoreSittingCash)
+            ) {
+              normalizedAccount.ignoreSittingCash = accountSettingsOverride.ignoreSittingCash;
+            }
           }
           const defaultBeneficiary = accountBeneficiaries.defaultBeneficiary || null;
           if (defaultBeneficiary) {


### PR DESCRIPTION
## Summary
- add support for the `ignoreSittingCash` account setting and include it in the summary payload
- skip generating cash TODO items when balances are below the configured ignore threshold
- document the new setting in the example accounts configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e544cbd6dc832dab0b7896f8369461