### PR TITLE
Include ignoreSittingCash in summary accounts

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -4555,6 +4555,11 @@ app.get('/api/summary', async function (req, res) {
         rebalancePeriod: Number.isFinite(account.rebalancePeriod)
           ? Math.round(account.rebalancePeriod)
           : null,
+        ignoreSittingCash:
+          typeof account.ignoreSittingCash === 'number' &&
+          Number.isFinite(account.ignoreSittingCash)
+            ? Math.max(0, account.ignoreSittingCash)
+            : null,
         isDefault: defaultAccountId ? account.id === defaultAccountId : false,
       };
     });


### PR DESCRIPTION
## Summary
- include each account's ignoreSittingCash threshold in the /api/summary response so the UI can suppress cash TODOs when configured

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e546baf2a4832db29239c935822638