### PR TITLE
Fix annualized return dialog visibility

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -13225,7 +13225,7 @@ export default function App() {
     if (!showReturnBreakdown) {
       return;
     }
-    if (!fundingSummaryForDisplay?.returnBreakdown?.length) {
+    if (!Array.isArray(fundingSummaryForDisplay?.returnBreakdown)) {
       setShowReturnBreakdown(false);
     }
   }, [showReturnBreakdown, fundingSummaryForDisplay]);
@@ -13330,7 +13330,7 @@ export default function App() {
   };
 
   const handleShowAnnualizedReturnDetails = useCallback(() => {
-    if (!fundingSummaryForDisplay?.returnBreakdown?.length) {
+    if (!Array.isArray(fundingSummaryForDisplay?.returnBreakdown)) {
       return;
     }
     setShowReturnBreakdown(true);
@@ -14899,7 +14899,7 @@ export default function App() {
           </ul>
         </div>
       ) : null}
-      {showReturnBreakdown && fundingSummaryForDisplay?.returnBreakdown?.length > 0 && (
+      {showReturnBreakdown && Array.isArray(fundingSummaryForDisplay?.returnBreakdown) && (
         <AnnualizedReturnDialog
           onClose={handleCloseAnnualizedReturnDetails}
           annualizedRate={fundingSummaryForDisplay.annualizedReturnRate}

--- a/client/src/components/SummaryMetrics.jsx
+++ b/client/src/components/SummaryMetrics.jsx
@@ -806,8 +806,7 @@ export default function SummaryMetrics({
     annualizedReturnRate > 0 ? 'positive' : annualizedReturnRate < 0 ? 'negative' : 'neutral';
   const canShowReturnBreakdown =
     typeof onShowAnnualizedReturn === 'function' &&
-    Array.isArray(fundingSummary?.returnBreakdown) &&
-    fundingSummary.returnBreakdown.length > 0;
+    Array.isArray(fundingSummary?.returnBreakdown);
 
   const safeTotalEquity = Number.isFinite(totalEquity)
     ? totalEquity


### PR DESCRIPTION
## Summary
- allow the annualized return metric to open its dialog whenever return breakdown data is available
- keep the dialog mount and interactions active even when the breakdown list is empty

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e48241170832d8c1ed80d6bd160e1)